### PR TITLE
Add trailing widgets for SettingsTile

### DIFF
--- a/example/lib/screens/languages_screen.dart
+++ b/example/lib/screens/languages_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
 
 class LanguagesScreen extends StatefulWidget {
   @override
@@ -6,10 +7,50 @@ class LanguagesScreen extends StatefulWidget {
 }
 
 class _LanguagesScreenState extends State<LanguagesScreen> {
+  int languageIndex = 0;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Languages')),
+      body: SettingsList(
+        sections: [
+          SettingsSection(tiles: [
+            SettingsTile(
+              title: "English",
+              trailing: trailingWidget(0),
+              onTap: () => changeLanguage(0),
+            ),
+            SettingsTile(
+              title: "Spanish",
+              trailing: trailingWidget(1),
+              onTap: () => changeLanguage(1),
+            ),
+            SettingsTile(
+              title: "Chinese",
+              trailing: trailingWidget(2),
+              onTap: () => changeLanguage(2),
+            ),
+            SettingsTile(
+              title: "German",
+              trailing: trailingWidget(3),
+              onTap: () => changeLanguage(3),
+            ),
+          ]),
+        ],
+      ),
     );
+  }
+
+  Widget trailingWidget(int index) {
+    return (languageIndex == index)
+        ? Icon(Icons.check, color: Colors.blue)
+        : Icon(null);
+  }
+
+  void changeLanguage(int index) {
+    setState(() {
+      languageIndex = index;
+    });
   }
 }

--- a/example/lib/screens/languages_screen.dart
+++ b/example/lib/screens/languages_screen.dart
@@ -19,22 +19,30 @@ class _LanguagesScreenState extends State<LanguagesScreen> {
             SettingsTile(
               title: "English",
               trailing: trailingWidget(0),
-              onTap: () => changeLanguage(0),
+              onTap: () {
+                changeLanguage(0);
+              },
             ),
             SettingsTile(
               title: "Spanish",
               trailing: trailingWidget(1),
-              onTap: () => changeLanguage(1),
+              onTap: () {
+                changeLanguage(1);
+              },
             ),
             SettingsTile(
               title: "Chinese",
               trailing: trailingWidget(2),
-              onTap: () => changeLanguage(2),
+              onTap: () {
+                changeLanguage(2);
+              },
             ),
             SettingsTile(
               title: "German",
               trailing: trailingWidget(3),
-              onTap: () => changeLanguage(3),
+              onTap: () {
+                changeLanguage(3);
+              },
             ),
           ]),
         ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,8 +16,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-
 flutter:
   uses-material-design: true
-  assets:
-    - assets/

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -18,6 +18,7 @@ class CupertinoSettingsItem extends StatefulWidget {
     @required this.label,
     this.subtitle,
     this.leading,
+    this.trailing,
     this.value,
     this.hasDetails = false,
     this.onPress,
@@ -29,6 +30,7 @@ class CupertinoSettingsItem extends StatefulWidget {
   final String label;
   final String subtitle;
   final Widget leading;
+  final Widget trailing;
   final SettingsItemType type;
   final String value;
   final bool hasDetails;
@@ -140,7 +142,17 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           );
         }
 
-        if (widget.hasDetails) {
+        if (widget.trailing != null) {
+          rightRowChildren.add(
+            Padding(
+              padding: const EdgeInsets.only(
+                top: 0.5,
+                left: 2.25,
+              ),
+              child: widget.trailing,
+            ),
+          );
+        } else {
           rightRowChildren.add(
             Padding(
               padding: const EdgeInsets.only(

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -10,6 +10,7 @@ class SettingsTile extends StatelessWidget {
   final String title;
   final String subtitle;
   final Widget leading;
+  final Widget trailing;
   final VoidCallback onTap;
   final Function(bool value) onToggle;
   final bool switchValue;
@@ -20,6 +21,7 @@ class SettingsTile extends StatelessWidget {
     @required this.title,
     this.subtitle,
     this.leading,
+    this.trailing,
     this.onTap,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
@@ -31,6 +33,7 @@ class SettingsTile extends StatelessWidget {
     @required this.title,
     this.subtitle,
     this.leading,
+    this.trailing,
     @required this.onToggle,
     @required this.switchValue,
   })  : _tileType = _SettingsTileType.switchTile,
@@ -60,7 +63,8 @@ class SettingsTile extends StatelessWidget {
         type: SettingsItemType.modal,
         label: title,
         value: subtitle,
-        hasDetails: true,
+        trailing: trailing,
+        hasDetails: false,
         leading: leading,
         onPress: onTap,
       );
@@ -81,6 +85,7 @@ class SettingsTile extends StatelessWidget {
         title: Text(title),
         subtitle: subtitle != null ? Text(subtitle) : null,
         leading: leading,
+        trailing: trailing,
         onTap: onTap,
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,14 +13,13 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.0
+  pedantic: ^1.8.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # To add assets to your package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
@@ -31,7 +30,6 @@ flutter:
   #
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
-
   # To add custom fonts to your package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a


### PR DESCRIPTION
The optional trailing widget allows screens like the LanguagesScreen to have more functionality.

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-12-13 at 14 46 23](https://user-images.githubusercontent.com/17091545/70837108-5a559400-1db7-11ea-86d7-5f4e6b6cdbb3.png)
