### PR TITLE
Cupertino Settings Item Button Response

### DIFF
--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -195,8 +195,20 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       behavior: HitTestBehavior.opaque,
       onTap: () {
         if (widget.onPress != null && widget.enabled) {
+          setState(() {
+            pressed = true;
+          });
+          
           widget.onPress();
+          
+          Future.delayed(const Duration(milliseconds: 100), () {
+            setState(() {
+              pressed = false;
+            });
+          });
         }
+
+
       },
       onTapUp: (_) {
         if (widget.enabled) {

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -194,21 +194,22 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {
-        if (widget.onPress != null && widget.enabled) {
+        if ((widget.onPress != null || widget.onToggle != null) &&
+            widget.enabled) {
           setState(() {
             pressed = true;
           });
-          
-          widget.onPress();
-          
+
+          if (widget.onPress != null) {
+            widget.onPress();
+          }
+
           Future.delayed(const Duration(milliseconds: 100), () {
             setState(() {
               pressed = false;
             });
           });
         }
-
-
       },
       onTapUp: (_) {
         if (widget.enabled) {


### PR DESCRIPTION
Gives the Cupertino Settings Item a background change when pressed. (The current state only triggers a background color change when long pressed) Also works with enabled/disabled tiles and Toggles.