### PR TITLE
Custom Colors support for SettingsList

### DIFF
--- a/lib/src/settings_list.dart
+++ b/lib/src/settings_list.dart
@@ -16,7 +16,7 @@ class SettingsList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Theme.of(context).brightness == Brightness.light
-          ? backgroundGray
+          ? backgroundColor ?? backgroundGray
           : backgroundColor ?? Colors.black,
       child: ListView.builder(
         itemCount: sections.length,

--- a/lib/src/settings_list.dart
+++ b/lib/src/settings_list.dart
@@ -5,19 +5,23 @@ import 'package:settings_ui/src/settings_section.dart';
 class SettingsList extends StatelessWidget {
   final List<SettingsSection> sections;
   final Color backgroundColor;
+  final Color lightBackgroundColor;
+  final Color darkBackgroundColor;
 
   const SettingsList({
     Key key,
     this.sections,
     this.backgroundColor,
+    this.lightBackgroundColor,
+    this.darkBackgroundColor,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       color: Theme.of(context).brightness == Brightness.light
-          ? backgroundColor ?? backgroundGray
-          : backgroundColor ?? Colors.black,
+          ? backgroundColor ?? lightBackgroundColor ?? backgroundGray
+          : backgroundColor ?? darkBackgroundColor ?? Colors.black,
       child: ListView.builder(
         itemCount: sections.length,
         itemBuilder: (context, index) {


### PR DESCRIPTION
With this modification you can : 
  - Provide a custom color to use independently from the Theme brightness (_backgroundColor_)
  - Provide a custom color to use in Dark  mode (_darkBackgroundColor_)
  - Provide a custom color to use in Light mode (_lightBackgroundColor_)
If no Colors are provided, will use a grey background in light mode and a black background in dark mode.
If a _backgroundColor_ is provided, it overrides _darkBackgroundColor_ and _lightBackgroundColor_
In the end it allows more theming of the UI by the developer.