### PR TITLE
Fix cupertino toggle bug.

### DIFF
--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -248,11 +248,14 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
             }
           });
         }
-        if (widget.type == SettingsItemType.toggle && mounted) {
-          setState(() {
-            _checked = !_checked;
-            widget.onToggle(_checked);
-          });
+        
+        if (widget.type == SettingsItemType.toggle && widget.enabled) {
+          if (mounted) {
+            setState(() {
+              _checked = !_checked;
+              widget.onToggle(_checked);
+            });
+          }
         }
       },
       onTapUp: (_) {


### PR DESCRIPTION
This PR fixes the Cupertino toggle item bug that calls `onToggle` even when the tile disabled.