### PR TITLE
Removed TargetExtensions in favor of dart:io for macOS support.

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,8 +1,0 @@
-import 'package:flutter/material.dart';
-
-extension TargetExtensions on TargetPlatform {
-  bool isIOS(BuildContext context) =>
-      Theme.of(context).platform == TargetPlatform.iOS;
-  bool isAndroid(BuildContext context) =>
-      Theme.of(context).platform == TargetPlatform.android;
-}

--- a/lib/src/settings_section.dart
+++ b/lib/src/settings_section.dart
@@ -1,7 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/abstract_section.dart';
 import 'package:settings_ui/src/cupertino_settings_section.dart';
-import 'package:settings_ui/src/extensions.dart';
 import 'package:settings_ui/src/settings_tile.dart';
 
 import 'defines.dart';
@@ -29,8 +30,7 @@ class SettingsSection extends AbstractSection {
 
   @override
   Widget build(BuildContext context) {
-    final platform = Theme.of(context).platform;
-    if (platform.isIOS(context)) {
+    if (Platform.isIOS || Platform.isMacOS) {
       return iosSection();
     } else {
       return androidSection(context);

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -1,7 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/cupertino_settings_item.dart';
-import 'package:settings_ui/src/extensions.dart';
 
 import 'defines.dart';
 
@@ -74,8 +75,7 @@ class SettingsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final platform = Theme.of(context).platform;
-    if (platform.isIOS(context)) {
+    if (Platform.isIOS || Platform.isMacOS) {
       return iosTile(context);
     } else {
       return androidTile(context);


### PR DESCRIPTION
By using dart:io we can enable the iOS style on macOS.