### PR TITLE
Added additional theming possibilities for switches

### DIFF
--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -24,8 +24,10 @@ class SettingsTile extends StatelessWidget {
   final bool enabled;
   final TextStyle? titleTextStyle;
   final TextStyle? subtitleTextStyle;
-  final Color? switchInactiveColor;
-  final Color? switchActiveColor;
+  final Color? switchInactiveThumbColor;
+  final Color? switchInactiveTrackColor;
+  final Color? switchActiveThumbColor;
+  final Color? switchActiveTrackColor;
   final _SettingsTileType _tileType;
 
   const SettingsTile({
@@ -43,8 +45,10 @@ class SettingsTile extends StatelessWidget {
     this.subtitleTextStyle,
     this.enabled = true,
     this.onPressed,
-    this.switchInactiveColor,
-    this.switchActiveColor,
+    this.switchInactiveThumbColor,
+    this.switchInactiveTrackColor,
+    this.switchActiveThumbColor,
+    this.switchActiveTrackColor,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -65,8 +69,10 @@ class SettingsTile extends StatelessWidget {
     required this.switchValue,
     this.titleTextStyle,
     this.subtitleTextStyle,
-    this.switchInactiveColor,
-    this.switchActiveColor,
+    this.switchInactiveThumbColor,
+    this.switchInactiveTrackColor,
+    this.switchActiveThumbColor,
+    this.switchActiveTrackColor,
   })  : _tileType = _SettingsTileType.switchTile,
         onTap = null,
         onPressed = null,
@@ -100,7 +106,7 @@ class SettingsTile extends StatelessWidget {
         switchValue: switchValue,
         onToggle: onToggle,
         labelTextStyle: titleTextStyle,
-        switchActiveColor: switchActiveColor,
+        switchActiveColor: switchActiveThumbColor,
         subtitleTextStyle: subtitleTextStyle,
         valueTextStyle: subtitleTextStyle,
         trailing: trailing,
@@ -130,8 +136,10 @@ class SettingsTile extends StatelessWidget {
       return SwitchListTile(
         secondary: leading,
         value: switchValue!,
-        inactiveThumbColor: switchInactiveColor,
-        activeColor: switchActiveColor,
+        inactiveThumbColor: switchInactiveThumbColor,
+        inactiveTrackColor: switchInactiveTrackColor,
+        activeTrackColor: switchActiveTrackColor,
+        activeColor: switchActiveThumbColor,
         onChanged: enabled ? onToggle : null,
         title: Text(
           title,

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -24,6 +24,7 @@ class SettingsTile extends StatelessWidget {
   final bool enabled;
   final TextStyle? titleTextStyle;
   final TextStyle? subtitleTextStyle;
+  final Color? switchInactiveColor;
   final Color? switchActiveColor;
   final _SettingsTileType _tileType;
 
@@ -42,6 +43,7 @@ class SettingsTile extends StatelessWidget {
     this.subtitleTextStyle,
     this.enabled = true,
     this.onPressed,
+    this.switchInactiveColor,
     this.switchActiveColor,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
@@ -63,6 +65,7 @@ class SettingsTile extends StatelessWidget {
     required this.switchValue,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.switchInactiveColor,
     this.switchActiveColor,
   })  : _tileType = _SettingsTileType.switchTile,
         onTap = null,
@@ -127,6 +130,7 @@ class SettingsTile extends StatelessWidget {
       return SwitchListTile(
         secondary: leading,
         value: switchValue!,
+        inactiveThumbColor: switchInactiveColor,
         activeColor: switchActiveColor,
         onChanged: enabled ? onToggle : null,
         title: Text(


### PR DESCRIPTION
Implemented active/inactive colors for the switch and also the ability to adjust both the thumb (dot) and the background (track).

This only works for Android at the moment. The IOS switch uses a [constant value](https://api.flutter.dev/flutter/cupertino/CupertinoColors/inactiveGray-constant.html) for its color and could only be changed by create a modified version of the class.