### PR TITLE
[null-safety] Fix type cast error

### DIFF
--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -171,7 +171,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         );
         break;
       case SettingsItemType.modal:
-        final List<Widget?> rightRowChildren = [];
+        final List<Widget> rightRowChildren = [];
         if (widget.value != null) {
           rightRowChildren.add(
             Padding(
@@ -208,7 +208,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         if (widget.trailing == null && widget.iosChevron != null) {
           rightRowChildren.add(
             widget.iosChevronPadding == null
-                ? widget.iosChevron
+                ? widget.iosChevron!
                 : Padding(
                     padding: widget.iosChevronPadding!,
                     child: widget.iosChevron,
@@ -222,7 +222,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           Row(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.end,
-            children: rightRowChildren as List<Widget>,
+            children: rightRowChildren,
           ),
         );
 


### PR DESCRIPTION
rightRowChildren should be non-nullable

This should fix #71 and #70 