### PR TITLE
Platform detection via Theme.of(), fix a bug in iOS with a long subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0-nullsafety.2] - [April 6, 2021]
+* Dropped use of 'dart:io'
+* Use Theme.of(context) to detect platform
+* Fixed a bug with long subtitles in iOS
+
 ## [1.0.0-nullsafety.1] - [February 26, 2021]
 * Null safety preview release
 

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -297,7 +297,6 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         ),
         height: widget.subtitle == null ? 44.0 : 57.0,
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: rowChildren,
         ),
       ),

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -11,6 +11,8 @@ enum SettingsItemType {
 
 typedef void PressOperationCallback();
 
+const _spacer = Expanded(child: SizedBox.shrink());
+
 class CupertinoSettingsItem extends StatefulWidget {
   const CupertinoSettingsItem({
     required this.type,
@@ -72,13 +74,12 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
 
     final ThemeData theme = Theme.of(context);
     final ListTileTheme tileTheme = ListTileTheme.of(context);
-    late IconThemeData iconThemeData;
-    if (widget.leading != null)
-      iconThemeData = IconThemeData(
-        color: widget.enabled
-            ? _iconColor(theme, tileTheme)
-            : CupertinoColors.inactiveGray,
-      );
+
+    final iconThemeData = IconThemeData(
+      color: widget.enabled
+          ? _iconColor(theme, tileTheme)
+          : CupertinoColors.inactiveGray,
+    );
 
     Widget? leadingIcon;
     if (widget.leading != null) {
@@ -118,13 +119,13 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       titleSection = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          const Padding(padding: EdgeInsets.only(top: 8.5)),
+          const SizedBox(height: 8.5),
           Text(
             widget.label,
             overflow: TextOverflow.ellipsis,
             style: widget.labelTextStyle,
           ),
-          const Padding(padding: EdgeInsets.only(top: 4.0)),
+          const SizedBox(height: 4.0),
           Text(
             widget.subtitle!,
             maxLines: widget.subtitleMaxLines,
@@ -140,61 +141,67 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     }
 
     rowChildren.add(
-      Expanded(
-        child: Padding(
-          padding: const EdgeInsetsDirectional.only(
-            start: 15.0,
-            end: 15.0,
-          ),
-          child: titleSection,
+      Padding(
+        padding: const EdgeInsetsDirectional.only(
+          start: 15.0,
+          end: 15.0,
         ),
+        child: titleSection,
       ),
     );
 
     switch (widget.type) {
       case SettingsItemType.toggle:
-        rowChildren.add(
-          Padding(
-            padding: const EdgeInsetsDirectional.only(end: 11.0),
-            child: CupertinoSwitch(
-              value: widget.switchValue!,
-              activeColor: widget.enabled
-                  ? (widget.switchActiveColor ?? Theme.of(context).accentColor)
-                  : CupertinoColors.inactiveGray,
-              onChanged: !widget.enabled
-                  ? null
-                  : (bool value) {
-                      widget.onToggle!(value);
-                    },
-            ),
-          ),
-        );
-        break;
-      case SettingsItemType.modal:
-        final List<Widget?> rightRowChildren = [];
-        if (widget.value != null) {
-          rightRowChildren.add(
+        rowChildren
+          ..add(_spacer)
+          ..add(
             Padding(
-              padding: const EdgeInsetsDirectional.only(
-                top: 1.5,
-                end: 2.25,
+              padding: const EdgeInsetsDirectional.only(end: 11.0),
+              child: CupertinoSwitch(
+                value: widget.switchValue!,
+                activeColor: widget.enabled
+                    ? (widget.switchActiveColor ??
+                        Theme.of(context).accentColor)
+                    : CupertinoColors.inactiveGray,
+                onChanged: !widget.enabled
+                    ? null
+                    : (bool value) {
+                        widget.onToggle!(value);
+                      },
               ),
-              child: Text(
-                widget.value!,
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.end,
-                style: widget.valueTextStyle ??
-                    TextStyle(
-                      color: CupertinoColors.inactiveGray,
-                      fontSize: 16,
-                    ),
+            ),
+          );
+        break;
+
+      case SettingsItemType.modal:
+        if (widget.value == null) {
+          rowChildren.add(_spacer);
+        } else {
+          rowChildren.add(
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  top: 1.5,
+                  end: 2.25,
+                ),
+                child: Text(
+                  widget.value!,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                  style: widget.valueTextStyle ??
+                      TextStyle(
+                        color: CupertinoColors.inactiveGray,
+                        fontSize: 16,
+                      ),
+                ),
               ),
             ),
           );
         }
 
+        final List<Widget> endRowChildren = [];
         if (widget.trailing != null) {
-          rightRowChildren.add(
+          endRowChildren.add(
             Padding(
               padding: const EdgeInsetsDirectional.only(
                 top: 0.5,
@@ -206,9 +213,9 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         }
 
         if (widget.trailing == null && widget.iosChevron != null) {
-          rightRowChildren.add(
+          endRowChildren.add(
             widget.iosChevronPadding == null
-                ? widget.iosChevron
+                ? widget.iosChevron ?? const SizedBox.shrink()
                 : Padding(
                     padding: widget.iosChevronPadding!,
                     child: widget.iosChevron,
@@ -216,16 +223,15 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           );
         }
 
-        rightRowChildren.add(const SizedBox(width: 8.5));
+        endRowChildren.add(const SizedBox(width: 8.5));
 
         rowChildren.add(
           Row(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.end,
-            children: rightRowChildren as List<Widget>,
+            children: endRowChildren,
           ),
         );
-
         break;
     }
 
@@ -291,6 +297,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         ),
         height: widget.subtitle == null ? 44.0 : 57.0,
         child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: rowChildren,
         ),
       ),

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -101,10 +101,14 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       );
     }
 
-    Widget titleSection;
+    final Widget titleSection;
+
     if (widget.subtitle == null) {
       titleSection = Padding(
-        padding: EdgeInsets.only(top: 1.5),
+        padding: const EdgeInsetsDirectional.only(
+          start: 15.0,
+          end: 15.0,
+        ),
         child: Text(
           widget.label,
           overflow: TextOverflow.ellipsis,
@@ -116,44 +120,44 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         ),
       );
     } else {
-      titleSection = Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          const SizedBox(height: 8.5),
-          Text(
-            widget.label,
-            overflow: TextOverflow.ellipsis,
-            style: widget.labelTextStyle,
+      titleSection = Expanded(
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(
+            start: 15.0,
+            end: 15.0,
           ),
-          const SizedBox(height: 4.0),
-          Text(
-            widget.subtitle!,
-            maxLines: widget.subtitleMaxLines,
-            overflow: TextOverflow.ellipsis,
-            style: widget.subtitleTextStyle ??
-                TextStyle(
-                  fontSize: 12.0,
-                  letterSpacing: -0.2,
-                ),
-          )
-        ],
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                widget.label,
+                overflow: TextOverflow.ellipsis,
+                style: widget.labelTextStyle,
+              ),
+              const SizedBox(height: 2.5),
+              Text(
+                widget.subtitle!,
+                maxLines: widget.subtitleMaxLines,
+                overflow: TextOverflow.ellipsis,
+                style: widget.subtitleTextStyle ??
+                    TextStyle(
+                      fontSize: 12.0,
+                      letterSpacing: -0.2,
+                    ),
+              ),
+            ],
+          ),
+        ),
       );
     }
 
-    rowChildren.add(
-      Padding(
-        padding: const EdgeInsetsDirectional.only(
-          start: 15.0,
-          end: 15.0,
-        ),
-        child: titleSection,
-      ),
-    );
+    rowChildren.add(titleSection);
 
     switch (widget.type) {
       case SettingsItemType.toggle:
         rowChildren
-          ..add(_spacer)
           ..add(
             Padding(
               padding: const EdgeInsetsDirectional.only(end: 11.0),

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -104,56 +104,50 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     final Widget titleSection;
 
     if (widget.subtitle == null) {
-      titleSection = Padding(
+      titleSection = Text(
+        widget.label,
+        overflow: TextOverflow.ellipsis,
+        style: widget.labelTextStyle ??
+            TextStyle(
+              fontSize: 16,
+              color: widget.enabled ? null : CupertinoColors.inactiveGray,
+            ),
+      );
+    } else {
+      titleSection = Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            widget.label,
+            overflow: TextOverflow.ellipsis,
+            style: widget.labelTextStyle,
+          ),
+          const SizedBox(height: 2.5),
+          Text(
+            widget.subtitle!,
+            maxLines: widget.subtitleMaxLines,
+            overflow: TextOverflow.ellipsis,
+            style: widget.subtitleTextStyle ??
+                TextStyle(
+                  fontSize: 12.0,
+                  letterSpacing: -0.2,
+                ),
+          ),
+        ],
+      );
+    }
+
+    rowChildren.add(Expanded(
+      child: Padding(
         padding: const EdgeInsetsDirectional.only(
           start: 15.0,
           end: 15.0,
         ),
-        child: Text(
-          widget.label,
-          overflow: TextOverflow.ellipsis,
-          style: widget.labelTextStyle ??
-              TextStyle(
-                fontSize: 16,
-                color: widget.enabled ? null : CupertinoColors.inactiveGray,
-              ),
-        ),
-      );
-    } else {
-      titleSection = Expanded(
-        child: Padding(
-          padding: const EdgeInsetsDirectional.only(
-            start: 15.0,
-            end: 15.0,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text(
-                widget.label,
-                overflow: TextOverflow.ellipsis,
-                style: widget.labelTextStyle,
-              ),
-              const SizedBox(height: 2.5),
-              Text(
-                widget.subtitle!,
-                maxLines: widget.subtitleMaxLines,
-                overflow: TextOverflow.ellipsis,
-                style: widget.subtitleTextStyle ??
-                    TextStyle(
-                      fontSize: 12.0,
-                      letterSpacing: -0.2,
-                    ),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    rowChildren.add(titleSection);
+        child: titleSection,
+      ),
+    ));
 
     switch (widget.type) {
       case SettingsItemType.toggle:

--- a/lib/src/settings_section.dart
+++ b/lib/src/settings_section.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/abstract_section.dart';
@@ -30,12 +28,19 @@ class SettingsSection extends AbstractSection {
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWeb) {
-      return iosSection();
-    } else if (Platform.isIOS || Platform.isMacOS) {
-      return iosSection();
-    } else {
-      return androidSection(context);
+    final platform = Theme.of(context).platform;
+
+    switch (platform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return iosSection();
+
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        return androidSection(context);
+
+      default:
+        return iosSection();
     }
   }
 

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/cupertino_settings_item.dart';
@@ -75,12 +73,19 @@ class SettingsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWeb) {
-      return iosTile(context);
-    } else if (Platform.isIOS || Platform.isMacOS) {
-      return iosTile(context);
-    } else {
-      return androidTile(context);
+    final platform = Theme.of(context).platform;
+
+    switch (platform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return iosTile(context);
+
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        return androidTile(context);
+
+      default:
+        return iosTile(context);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: settings_ui
 description: Create native settings for Flutter app in minutes. Use single interfaces to build
-version: 1.0.0-nullsafety.1
+version: 1.0.0-nullsafety.2
 homepage: https://github.com/yako-dev/flutter-settings-ui
 
 environment:
@@ -14,6 +14,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.11.0
-
 
 flutter:


### PR DESCRIPTION
This pr fixes two issues with this fine plugin:

1) Drops use of `dart:io` completely and uses Theme.of() to detect the platform being used. This is best suited to how Flutter works, and also allows a user to influence part of the widget tree (for example, testing or demonstration purposes).

2) On iOS if the subtitle is too long, it caused a layout issue (showing those dreaded yellow/grey lines).