### PR TITLE
Fixed iOS title text getting cut off 

### DIFF
--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -11,8 +11,6 @@ enum SettingsItemType {
 
 typedef void PressOperationCallback();
 
-const _spacer = Expanded(child: SizedBox.shrink());
-
 class CupertinoSettingsItem extends StatefulWidget {
   const CupertinoSettingsItem({
     required this.type,
@@ -172,9 +170,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         break;
 
       case SettingsItemType.modal:
-        if (widget.value == null) {
-          rowChildren.add(_spacer);
-        } else {
+        if (widget.value != null) {
           rowChildren.add(
             Expanded(
               child: Padding(


### PR DESCRIPTION
Remove unnecessary spacer on iOS.
This should fix https://github.com/yako-dev/flutter-settings-ui/issues/78