### PR TITLE
Add SliderTile to ItemTypes

### DIFF
--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -11,6 +11,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool lockInBackground = true;
   bool notificationsEnabled = true;
+  var brightnessSlider = 40.0;
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +41,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
               title: 'Environment',
               subtitle: 'Production',
               leading: Icon(Icons.cloud_queue),
+            ),
+            SettingsTile.sliderTile(
+              leading: Icon(Icons.brightness_low),
+              trailing: Icon(Icons.brightness_high),
+              sliderValue: brightnessSlider,
+              sliderMin: 1,
+              sliderMax: 100,
+              sliderOnChanged: (double value) {
+                print('slider value: $value');
+                setState(() {
+                  brightnessSlider = value;
+                });
+              }, title: 'Brightness',
             ),
           ],
         ),

--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -46,15 +46,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
               title: 'Brightness',
               leading: Icon(Icons.brightness_low),
               trailing: Icon(Icons.brightness_high),
-              sliderValue: brightnessSlider,
-              sliderMin: 1,
-              sliderMax: 100,
-              sliderOnChanged: (double value) {
-                print('slider value: $value');
-                setState(() {
-                  brightnessSlider = value;
-                });
-              },
+              settingsSlider: SettingsSlider(
+                value: brightnessSlider,
+                min: 1,
+                max: 100,
+                onChanged: (double value) {
+                  print('slider value: $value');
+                  setState(() {
+                    brightnessSlider = value;
+                  });
+                },
+              ),
             ),
           ],
         ),

--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -43,6 +43,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               leading: Icon(Icons.cloud_queue),
             ),
             SettingsTile.sliderTile(
+              title: 'Brightness',
               leading: Icon(Icons.brightness_low),
               trailing: Icon(Icons.brightness_high),
               sliderValue: brightnessSlider,
@@ -53,7 +54,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 setState(() {
                   brightnessSlider = value;
                 });
-              }, title: 'Brightness',
+              },
             ),
           ],
         ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: example
 description: A new Flutter project.
 version: 1.0.0+1
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  device_preview: ^0.6.2-beta
+  device_preview: ^0.7.4
   settings_ui:
     path: ../
 

--- a/lib/settings_ui.dart
+++ b/lib/settings_ui.dart
@@ -4,3 +4,4 @@ export 'package:settings_ui/src/settings_section.dart';
 export 'package:settings_ui/src/settings_tile.dart';
 export 'package:settings_ui/src/settings_list.dart';
 export 'package:settings_ui/src/custom_section.dart';
+export 'package:settings_ui/src/item_type/settings_slider.dart';

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -7,6 +7,7 @@ import 'defines.dart';
 enum SettingsItemType {
   toggle,
   modal,
+  slider,
 }
 
 typedef void PressOperationCallback();
@@ -32,6 +33,15 @@ class CupertinoSettingsItem extends StatefulWidget {
     this.subtitleTextStyle,
     this.valueTextStyle,
     this.switchActiveColor,
+    this.sliderValue,
+    this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
+    this.min,
+    this.max,
+    this.divisions,
+    this.activeColor,
+    this.thumbColor,
   })  : assert(label != null),
         assert(type != null),
         assert(labelMaxLines == null || labelMaxLines > 0),
@@ -56,6 +66,17 @@ class CupertinoSettingsItem extends StatefulWidget {
   final TextStyle subtitleTextStyle;
   final TextStyle valueTextStyle;
   final Color switchActiveColor;
+
+  /// Values for Slider
+  final double sliderValue;
+  final ValueChanged<double> onChanged;
+  final ValueChanged<double> onChangeStart;
+  final ValueChanged<double> onChangeEnd;
+  final double min;
+  final double max;
+  final int divisions;
+  final Color activeColor;
+  final Color thumbColor;
 
   @override
   State<StatefulWidget> createState() => new CupertinoSettingsItemState();
@@ -100,42 +121,55 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     }
 
     Widget titleSection;
-    if (widget.subtitle == null) {
-      titleSection = Padding(
-        padding: EdgeInsets.only(top: 1.5),
-        child: Text(
-          widget.label,
-          overflow: TextOverflow.ellipsis,
-          style: widget.labelTextStyle ??
-              TextStyle(
-                fontSize: 16,
-                color: widget.enabled ? null : CupertinoColors.inactiveGray,
-              ),
-        ),
-      );
-    } else {
-      titleSection = Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          const Padding(padding: EdgeInsets.only(top: 8.5)),
-          Text(
+    if (widget.type != SettingsItemType.slider) {
+      if (widget.subtitle == null) {
+        titleSection = Padding(
+          padding: EdgeInsets.only(top: 1.5),
+          child: Text(
             widget.label,
             overflow: TextOverflow.ellipsis,
-            style: widget.labelTextStyle,
-          ),
-          const Padding(padding: EdgeInsets.only(top: 4.0)),
-          Text(
-            widget.subtitle,
-            maxLines: widget.subtitleMaxLines,
-            overflow: TextOverflow.ellipsis,
-            style: widget.subtitleTextStyle ??
+            style: widget.labelTextStyle ??
                 TextStyle(
-                  fontSize: 12.0,
-                  letterSpacing: -0.2,
+                  fontSize: 16,
+                  color: widget.enabled ? null : CupertinoColors.inactiveGray,
                 ),
-          )
-        ],
-      );
+          ),
+        );
+      } else {
+        titleSection = Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const Padding(padding: EdgeInsets.only(top: 8.5)),
+            Text(
+              widget.label,
+              overflow: TextOverflow.ellipsis,
+              style: widget.labelTextStyle,
+            ),
+            const Padding(padding: EdgeInsets.only(top: 4.0)),
+            Text(
+              widget.subtitle,
+              maxLines: widget.subtitleMaxLines,
+              overflow: TextOverflow.ellipsis,
+              style: widget.subtitleTextStyle ??
+                  TextStyle(
+                    fontSize: 12.0,
+                    letterSpacing: -0.2,
+                  ),
+            )
+          ],
+        );
+      }
+    } else {
+      titleSection = CupertinoSlider(
+          value: widget.sliderValue,
+          divisions: widget.divisions,
+          activeColor: widget.activeColor,
+          thumbColor: widget.thumbColor,
+          min: widget.min,
+          max: widget.max,
+          onChanged: widget.onChanged,
+          onChangeStart: widget.onChangeStart,
+          onChangeEnd: widget.onChangeEnd);
     }
 
     rowChildren.add(
@@ -151,6 +185,27 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     );
 
     switch (widget.type) {
+      case SettingsItemType.slider:
+        if (widget.trailing != null) {
+          Widget trailingIcon = IconTheme.merge(
+            data: IconThemeData(
+              color: widget.enabled
+                  ? _iconColor(theme, tileTheme)
+                  : CupertinoColors.inactiveGray,
+            ),
+            child: widget.trailing,
+          );
+
+          rowChildren.add(
+            Padding(
+              padding: const EdgeInsetsDirectional.only(
+                  top: 0.5, start: 2.25, end: 11.0),
+              child: trailingIcon,
+            ),
+          );
+        }
+        ;
+        break;
       case SettingsItemType.toggle:
         rowChildren.add(
           Padding(
@@ -225,6 +280,8 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           ),
         );
 
+        break;
+      case SettingsItemType.slider:
         break;
     }
 

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -37,11 +37,11 @@ class CupertinoSettingsItem extends StatefulWidget {
     this.sliderOnChanged,
     this.sliderOnChangeStart,
     this.sliderOnChangeEnd,
-    this.sliderMin = 0,
-    this.sliderMax = 1,
+    this.sliderMin,
+    this.sliderMax,
     this.sliderDivisions,
     this.sliderActiveColor,
-    this.sliderThumbColor = Colors.blue,
+    this.sliderThumbColor,
   })  : assert(labelMaxLines == null || labelMaxLines > 0),
         assert(subtitleMaxLines == null || subtitleMaxLines > 0);
 
@@ -144,6 +144,13 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
             Text(
               widget.label,
               overflow: TextOverflow.ellipsis,
+              style: widget.labelTextStyle,
+            ),
+            const Padding(padding: EdgeInsets.only(top: 4.0)),
+            Text(
+              widget.subtitle!,
+              maxLines: widget.subtitleMaxLines,
+              overflow: TextOverflow.ellipsis,
               style: widget.subtitleTextStyle ??
                   TextStyle(
                     fontSize: 12.0,
@@ -154,16 +161,46 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         );
       }
     } else {
-      titleSection = CupertinoSlider(
-          value: widget.sliderValue ?? 0,
-          divisions: widget.sliderDivisions,
-          activeColor: widget.sliderActiveColor,
-          thumbColor: widget.sliderThumbColor ?? Colors.blue,
-          min: widget.sliderMin ?? 0,
-          max: widget.sliderMax ?? 1,
-          onChanged: widget.sliderOnChanged,
-          onChangeStart: widget.sliderOnChangeStart,
-          onChangeEnd: widget.sliderOnChangeEnd);
+      if (widget.label.isEmpty) {
+        titleSection = CupertinoSlider(
+            value: widget.sliderValue ?? 0,
+            divisions: widget.sliderDivisions,
+            activeColor: widget.sliderActiveColor,
+            thumbColor: widget.sliderThumbColor ?? Colors.white,
+            min: widget.sliderMin ?? 0,
+            max: widget.sliderMax ?? 1,
+            onChanged: widget.sliderOnChanged,
+            onChangeStart: widget.sliderOnChangeStart,
+            onChangeEnd: widget.sliderOnChangeEnd);
+      } else {
+        titleSection = Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            if (widget.label.isNotEmpty)
+              const Padding(padding: EdgeInsets.only(top: 4)),
+            if (widget.label.isNotEmpty)
+              Text(
+                widget.label,
+                overflow: TextOverflow.ellipsis,
+                style: widget.labelTextStyle,
+              ),
+            Expanded(
+              child: CupertinoSlider(
+                  value: widget.sliderValue ?? 0,
+                  divisions: widget.sliderDivisions,
+                  activeColor: widget.sliderActiveColor,
+                  thumbColor: widget.sliderThumbColor ?? Colors.white,
+                  min: widget.sliderMin ?? 0,
+                  max: widget.sliderMax ?? 1,
+                  onChanged: widget.sliderOnChanged,
+                  onChangeStart: widget.sliderOnChangeStart,
+                  onChangeEnd: widget.sliderOnChangeEnd),
+            ),
+            if (widget.label.isNotEmpty)
+              const Padding(padding: EdgeInsets.only(top: 8.5)),
+          ],
+        );
+      }
     }
 
     rowChildren.add(
@@ -339,12 +376,21 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
               isLargeScreen ? BorderRadius.all(Radius.circular(20)) : null,
           color: calculateBackgroundColor(context),
         ),
-        height: widget.subtitle == null ? 44.0 : 57.0,
+        height: calculateHeight(),
         child: Row(
           children: rowChildren,
         ),
       ),
     );
+  }
+
+  double calculateHeight() {
+    if (widget.subtitle != null) return 57.0;
+    if (widget.type == SettingsItemType.slider) {
+      if (widget.label.isEmpty) return 44.0;
+      return 57.0;
+    }
+    return 44.0;
   }
 
   Color calculateBackgroundColor(BuildContext context) =>

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:settings_ui/src/item_type/settings_slider.dart';
 
 import 'colors.dart';
 import 'defines.dart';
@@ -35,15 +36,7 @@ class CupertinoSettingsItem extends StatefulWidget {
     this.subtitleTextStyle,
     this.valueTextStyle,
     this.switchActiveColor,
-    this.sliderValue,
-    this.sliderOnChanged,
-    this.sliderOnChangeStart,
-    this.sliderOnChangeEnd,
-    this.sliderMin,
-    this.sliderMax,
-    this.sliderDivisions,
-    this.sliderActiveColor,
-    this.sliderThumbColor,
+    this.settingsSlider,
   })  : assert(labelMaxLines == null || labelMaxLines > 0),
         assert(subtitleMaxLines == null || subtitleMaxLines > 0);
 
@@ -66,17 +59,7 @@ class CupertinoSettingsItem extends StatefulWidget {
   final TextStyle? subtitleTextStyle;
   final TextStyle? valueTextStyle;
   final Color? switchActiveColor;
-
-  /// Values for Slider
-  final double? sliderValue;
-  final ValueChanged<double>? sliderOnChanged;
-  final ValueChanged<double>? sliderOnChangeStart;
-  final ValueChanged<double>? sliderOnChangeEnd;
-  final double? sliderMin;
-  final double? sliderMax;
-  final int? sliderDivisions;
-  final Color? sliderActiveColor;
-  final Color? sliderThumbColor;
+  final SettingsSlider? settingsSlider;
 
   @override
   State<StatefulWidget> createState() => new CupertinoSettingsItemState();
@@ -160,15 +143,15 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       }
     } else {
       titleSection = CupertinoSlider(
-          value: widget.sliderValue!,
-          divisions: widget.sliderDivisions,
-          activeColor: widget.sliderActiveColor,
-          thumbColor: widget.sliderThumbColor!,
-          min: widget.sliderMin!,
-          max: widget.sliderMax!,
-          onChanged: widget.sliderOnChanged,
-          onChangeStart: widget.sliderOnChangeStart,
-          onChangeEnd: widget.sliderOnChangeEnd);
+          value: widget.settingsSlider!.value,
+          divisions: widget.settingsSlider!.divisions,
+          activeColor: widget.settingsSlider!.activeColor,
+          thumbColor: widget.settingsSlider!.thumbColor ?? CupertinoColors.white,
+          min: widget.settingsSlider!.min,
+          max: widget.settingsSlider!.max,
+          onChanged: widget.settingsSlider!.onChanged,
+          onChangeStart: widget.settingsSlider!.onChangeStart,
+          onChangeEnd: widget.settingsSlider!.onChangeEnd);
 
     }
 

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -34,17 +34,15 @@ class CupertinoSettingsItem extends StatefulWidget {
     this.valueTextStyle,
     this.switchActiveColor,
     this.sliderValue,
-    this.onChanged,
-    this.onChangeStart,
-    this.onChangeEnd,
-    this.min,
-    this.max,
-    this.divisions,
-    this.activeColor,
-    this.thumbColor,
-  })  : assert(label != null),
-        assert(type != null),
-        assert(labelMaxLines == null || labelMaxLines > 0),
+    this.sliderOnChanged,
+    this.sliderOnChangeStart,
+    this.sliderOnChangeEnd,
+    this.sliderMin = 0,
+    this.sliderMax = 1,
+    this.sliderDivisions,
+    this.sliderActiveColor,
+    this.sliderThumbColor = Colors.blue,
+  })  : assert(labelMaxLines == null || labelMaxLines > 0),
         assert(subtitleMaxLines == null || subtitleMaxLines > 0);
 
   final String label;
@@ -67,16 +65,16 @@ class CupertinoSettingsItem extends StatefulWidget {
   final TextStyle? valueTextStyle;
   final Color? switchActiveColor;
 
-  /// Values for Slider
-  final double sliderValue;
-  final ValueChanged<double> onChanged;
-  final ValueChanged<double> onChangeStart;
-  final ValueChanged<double> onChangeEnd;
-  final double min;
-  final double max;
-  final int divisions;
-  final Color activeColor;
-  final Color thumbColor;
+  // Values for Slider
+  final double? sliderValue;
+  final ValueChanged<double>? sliderOnChanged;
+  final ValueChanged<double>? sliderOnChangeStart;
+  final ValueChanged<double>? sliderOnChangeEnd;
+  final double? sliderMin;
+  final double? sliderMax;
+  final int? sliderDivisions;
+  final Color? sliderActiveColor;
+  final Color? sliderThumbColor;
 
   @override
   State<StatefulWidget> createState() => new CupertinoSettingsItemState();
@@ -131,13 +129,6 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           child: Text(
             widget.label,
             overflow: TextOverflow.ellipsis,
-            style: widget.labelTextStyle,
-          ),
-          const Padding(padding: EdgeInsets.only(top: 4.0)),
-          Text(
-            widget.subtitle!,
-            maxLines: widget.subtitleMaxLines,
-            overflow: TextOverflow.ellipsis,
             style: widget.subtitleTextStyle ??
                 TextStyle(
                   fontSize: 16,
@@ -153,13 +144,6 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
             Text(
               widget.label,
               overflow: TextOverflow.ellipsis,
-              style: widget.labelTextStyle,
-            ),
-            const Padding(padding: EdgeInsets.only(top: 4.0)),
-            Text(
-              widget.subtitle,
-              maxLines: widget.subtitleMaxLines,
-              overflow: TextOverflow.ellipsis,
               style: widget.subtitleTextStyle ??
                   TextStyle(
                     fontSize: 12.0,
@@ -171,15 +155,15 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       }
     } else {
       titleSection = CupertinoSlider(
-          value: widget.sliderValue,
-          divisions: widget.divisions,
-          activeColor: widget.activeColor,
-          thumbColor: widget.thumbColor,
-          min: widget.min,
-          max: widget.max,
-          onChanged: widget.onChanged,
-          onChangeStart: widget.onChangeStart,
-          onChangeEnd: widget.onChangeEnd);
+          value: widget.sliderValue ?? 0,
+          divisions: widget.sliderDivisions,
+          activeColor: widget.sliderActiveColor,
+          thumbColor: widget.sliderThumbColor ?? Colors.blue,
+          min: widget.sliderMin ?? 0,
+          max: widget.sliderMax ?? 1,
+          onChanged: widget.sliderOnChanged,
+          onChangeStart: widget.sliderOnChangeStart,
+          onChangeEnd: widget.sliderOnChangeEnd);
     }
 
     rowChildren.add(
@@ -203,7 +187,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
                   ? _iconColor(theme, tileTheme)
                   : CupertinoColors.inactiveGray,
             ),
-            child: widget.trailing,
+            child: widget.trailing!,
           );
 
           rowChildren.add(

--- a/lib/src/item_type/settings_slider.dart
+++ b/lib/src/item_type/settings_slider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/cupertino.dart';
+
+/// This slider object defines the values for both the material `Slider` and
+/// the iOS `CupertinoSlider`.
+class SettingsSlider {
+  final double value;
+  final ValueChanged<double> onChanged;
+  final ValueChanged<double>? onChangeStart;
+  final ValueChanged<double>? onChangeEnd;
+  final double min;
+  final double max;
+  final int? divisions;
+  final Color? activeColor;
+  final Color? thumbColor;
+
+  SettingsSlider(
+      {required this.value,
+      required this.onChanged,
+      this.onChangeStart,
+      this.onChangeEnd,
+      this.min = 0.0,
+      this.max = 1.0,
+      this.divisions,
+      this.activeColor,
+      this.thumbColor});
+}

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -29,15 +29,15 @@ class SettingsTile extends StatelessWidget {
   final _SettingsTileType _tileType;
 
   // Values for Slider
-  final double value;
-  final ValueChanged<double> onChanged;
-  final ValueChanged<double> onChangeStart;
-  final ValueChanged<double> onChangeEnd;
-  final double min;
-  final double max;
-  final int divisions;
-  final Color activeColor;
-  final Color thumbColor;
+  final double? sliderValue;
+  final ValueChanged<double>? sliderOnChanged;
+  final ValueChanged<double>? sliderOnChangeStart;
+  final ValueChanged<double>? sliderOnChangeEnd;
+  final double? sliderMin;
+  final double? sliderMax;
+  final int? sliderDivisions;
+  final Color? sliderActiveColor;
+  final Color? sliderThumbColor;
 
   const SettingsTile({
     Key? key,
@@ -54,7 +54,16 @@ class SettingsTile extends StatelessWidget {
     this.subtitleTextStyle,
     this.enabled = true,
     this.onPressed,
-    this.switchActiveColor, this.value, this.onChanged, this.onChangeStart, this.onChangeEnd, this.min, this.max, this.divisions, this.activeColor, this.thumbColor,
+    this.switchActiveColor,
+    this.sliderValue = 0.5,
+    this.sliderOnChanged,
+    this.sliderOnChangeStart,
+    this.sliderOnChangeEnd,
+    this.sliderMin = 0,
+    this.sliderMax = 1,
+    this.sliderDivisions,
+    this.sliderActiveColor,
+    this.sliderThumbColor = Colors.blue,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -75,7 +84,16 @@ class SettingsTile extends StatelessWidget {
     required this.switchValue,
     this.titleTextStyle,
     this.subtitleTextStyle,
-    this.switchActiveColor, this.value, this.onChanged, this.onChangeStart, this.onChangeEnd, this.min, this.max, this.divisions, this.activeColor, this.thumbColor,
+    this.switchActiveColor,
+    this.sliderValue = 0.5,
+    this.sliderOnChanged,
+    this.sliderOnChangeStart,
+    this.sliderOnChangeEnd,
+    this.sliderMin,
+    this.sliderMax,
+    this.sliderDivisions,
+    this.sliderActiveColor,
+    this.sliderThumbColor,
   })  : _tileType = _SettingsTileType.switchTile,
         onTap = null,
         onPressed = null,
@@ -86,35 +104,35 @@ class SettingsTile extends StatelessWidget {
         super(key: key);
 
   const SettingsTile.sliderTile({
-    Key key,
+    Key? key,
+    required this.title,
     this.titleMaxLines,
     this.leading,
     this.enabled = true,
     this.trailing,
-    @required this.value,
-    @required this.onChanged,
-    this.onChangeStart,
-    this.onChangeEnd,
-    this.min = 0.0,
-    this.max = 1.0,
-    this.divisions,
-    this.activeColor,
-    this.thumbColor = CupertinoColors.white,
     this.titleTextStyle,
     this.subtitleTextStyle,
-    this.switchActiveColor, this.title, this.subtitle, this.subtitleMaxLines, this.onToggle, this.switchValue,
+    this.switchActiveColor,
+    this.subtitle,
+    this.subtitleMaxLines,
+    this.onToggle,
+    this.switchValue,
+    this.sliderValue,
+    this.sliderOnChanged,
+    this.sliderOnChangeStart,
+    this.sliderOnChangeEnd,
+    this.sliderMin,
+    this.sliderMax,
+    this.sliderDivisions,
+    this.sliderActiveColor,
+    this.sliderThumbColor,
   })  : _tileType = _SettingsTileType.sliderTile,
         onTap = null,
         onPressed = null,
         iosChevron = null,
         iosChevronPadding = null,
         assert(titleMaxLines == null || titleMaxLines > 0),
-        assert(value != null),
-        assert(min != null),
-        assert(max != null),
-        assert(value >= min && value <= max),
-        assert(divisions == null || divisions > 0),
-        assert(thumbColor != null),
+        assert(sliderDivisions == null || sliderDivisions > 0),
         super(key: key);
 
   @override
@@ -145,15 +163,15 @@ class SettingsTile extends StatelessWidget {
         subtitleTextStyle: subtitleTextStyle,
         valueTextStyle: subtitleTextStyle,
         trailing: trailing,
-        sliderValue: value,
-        max: max,
-        min: min,
-        thumbColor: thumbColor,
-        activeColor: activeColor,
-        onChangeStart: onChangeStart,
-        onChangeEnd: onChangeEnd,
-        onChanged: onChanged,
-        divisions: divisions,
+        sliderValue: sliderValue,
+        sliderMax: sliderMax,
+        sliderMin: sliderMin,
+        sliderThumbColor: sliderThumbColor,
+        sliderActiveColor: sliderActiveColor,
+        sliderOnChangeStart: sliderOnChangeStart,
+        sliderOnChangeEnd: sliderOnChangeEnd,
+        sliderOnChanged: sliderOnChanged,
+        sliderDivisions: sliderDivisions,
       );
     } else if (_tileType == _SettingsTileType.switchTile) {
       return CupertinoSettingsItem(
@@ -217,24 +235,25 @@ class SettingsTile extends StatelessWidget {
     } else if (_tileType == _SettingsTileType.sliderTile) {
       return ListTile(
         title: Slider(
-          value: value,
-          min: min,
-          max: max,
-          onChangeStart: onChangeStart,
-          onChangeEnd: onChangeEnd,
-          onChanged: onChanged,),
+          value: sliderValue ?? 0,
+          min: sliderMin ?? 0,
+          max: sliderMax ?? 1,
+          onChangeStart: sliderOnChangeStart,
+          onChangeEnd: sliderOnChangeEnd,
+          onChanged: sliderOnChanged,
+        ),
         subtitle: subtitle != null
             ? Text(
-          subtitle,
-          style: subtitleTextStyle,
-          maxLines: subtitleMaxLines,
-          overflow: TextOverflow.ellipsis,
-        )
+                subtitle!,
+                style: subtitleTextStyle,
+                maxLines: subtitleMaxLines,
+                overflow: TextOverflow.ellipsis,
+              )
             : null,
         leading: leading,
         enabled: enabled,
         trailing: trailing,
-        onTap: onTapFunction(context),
+        onTap: onTapFunction(context) as void Function()?,
       );
     } else {
       return ListTile(

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/cupertino_settings_item.dart';
 
 import 'defines.dart';
 
-enum _SettingsTileType { simple, switchTile }
+enum _SettingsTileType { simple, switchTile, sliderTile }
 
 class SettingsTile extends StatelessWidget {
   final String title;
@@ -27,6 +28,17 @@ class SettingsTile extends StatelessWidget {
   final Color switchActiveColor;
   final _SettingsTileType _tileType;
 
+  // Values for Slider
+  final double value;
+  final ValueChanged<double> onChanged;
+  final ValueChanged<double> onChangeStart;
+  final ValueChanged<double> onChangeEnd;
+  final double min;
+  final double max;
+  final int divisions;
+  final Color activeColor;
+  final Color thumbColor;
+
   const SettingsTile({
     Key key,
     @required this.title,
@@ -42,7 +54,7 @@ class SettingsTile extends StatelessWidget {
     this.subtitleTextStyle,
     this.enabled = true,
     this.onPressed,
-    this.switchActiveColor,
+    this.switchActiveColor, this.value, this.onChanged, this.onChangeStart, this.onChangeEnd, this.min, this.max, this.divisions, this.activeColor, this.thumbColor,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -63,7 +75,7 @@ class SettingsTile extends StatelessWidget {
     @required this.switchValue,
     this.titleTextStyle,
     this.subtitleTextStyle,
-    this.switchActiveColor,
+    this.switchActiveColor, this.value, this.onChanged, this.onChangeStart, this.onChangeEnd, this.min, this.max, this.divisions, this.activeColor, this.thumbColor,
   })  : _tileType = _SettingsTileType.switchTile,
         onTap = null,
         onPressed = null,
@@ -71,6 +83,38 @@ class SettingsTile extends StatelessWidget {
         iosChevronPadding = null,
         assert(titleMaxLines == null || titleMaxLines > 0),
         assert(subtitleMaxLines == null || subtitleMaxLines > 0),
+        super(key: key);
+
+  const SettingsTile.sliderTile({
+    Key key,
+    this.titleMaxLines,
+    this.leading,
+    this.enabled = true,
+    this.trailing,
+    @required this.value,
+    @required this.onChanged,
+    this.onChangeStart,
+    this.onChangeEnd,
+    this.min = 0.0,
+    this.max = 1.0,
+    this.divisions,
+    this.activeColor,
+    this.thumbColor = CupertinoColors.white,
+    this.titleTextStyle,
+    this.subtitleTextStyle,
+    this.switchActiveColor, this.title, this.subtitle, this.subtitleMaxLines, this.onToggle, this.switchValue,
+  })  : _tileType = _SettingsTileType.sliderTile,
+        onTap = null,
+        onPressed = null,
+        iosChevron = null,
+        iosChevronPadding = null,
+        assert(titleMaxLines == null || titleMaxLines > 0),
+        assert(value != null),
+        assert(min != null),
+        assert(max != null),
+        assert(value >= min && value <= max),
+        assert(divisions == null || divisions > 0),
+        assert(thumbColor != null),
         super(key: key);
 
   @override
@@ -83,7 +127,33 @@ class SettingsTile extends StatelessWidget {
   }
 
   Widget iosTile(BuildContext context) {
-    if (_tileType == _SettingsTileType.switchTile) {
+    if (_tileType == _SettingsTileType.sliderTile) {
+      return CupertinoSettingsItem(
+        enabled: enabled,
+        type: SettingsItemType.slider,
+        label: title,
+        labelMaxLines: titleMaxLines,
+        leading: leading,
+        subtitle: subtitle,
+        subtitleMaxLines: subtitleMaxLines,
+        switchValue: switchValue,
+        onToggle: onToggle,
+        labelTextStyle: titleTextStyle,
+        switchActiveColor: switchActiveColor,
+        subtitleTextStyle: subtitleTextStyle,
+        valueTextStyle: subtitleTextStyle,
+        trailing: trailing,
+        sliderValue: value,
+        max: max,
+        min: min,
+        thumbColor: thumbColor,
+        activeColor: activeColor,
+        onChangeStart: onChangeStart,
+        onChangeEnd: onChangeEnd,
+        onChanged: onChanged,
+        divisions: divisions,
+      );
+    } else if (_tileType == _SettingsTileType.switchTile) {
       return CupertinoSettingsItem(
         enabled: enabled,
         type: SettingsItemType.toggle,
@@ -141,6 +211,28 @@ class SettingsTile extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               )
             : null,
+      );
+    } else if (_tileType == _SettingsTileType.sliderTile) {
+      return ListTile(
+        title: Slider(
+          value: value,
+          min: min,
+          max: max,
+          onChangeStart: onChangeStart,
+          onChangeEnd: onChangeEnd,
+          onChanged: onChanged,),
+        subtitle: subtitle != null
+            ? Text(
+          subtitle,
+          style: subtitleTextStyle,
+          maxLines: subtitleMaxLines,
+          overflow: TextOverflow.ellipsis,
+        )
+            : null,
+        leading: leading,
+        enabled: enabled,
+        trailing: trailing,
+        onTap: onTapFunction(context),
       );
     } else {
       return ListTile(

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -55,15 +55,15 @@ class SettingsTile extends StatelessWidget {
     this.enabled = true,
     this.onPressed,
     this.switchActiveColor,
-    this.sliderValue = 0.5,
+    this.sliderValue,
     this.sliderOnChanged,
     this.sliderOnChangeStart,
     this.sliderOnChangeEnd,
-    this.sliderMin = 0,
-    this.sliderMax = 1,
+    this.sliderMin,
+    this.sliderMax,
     this.sliderDivisions,
     this.sliderActiveColor,
-    this.sliderThumbColor = Colors.blue,
+    this.sliderThumbColor,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -105,7 +105,7 @@ class SettingsTile extends StatelessWidget {
 
   const SettingsTile.sliderTile({
     Key? key,
-    required this.title,
+    this.title = '',
     this.titleMaxLines,
     this.leading,
     this.enabled = true,
@@ -117,7 +117,7 @@ class SettingsTile extends StatelessWidget {
     this.subtitleMaxLines,
     this.onToggle,
     this.switchValue,
-    this.sliderValue,
+    required this.sliderValue,
     this.sliderOnChanged,
     this.sliderOnChangeStart,
     this.sliderOnChangeEnd,
@@ -233,28 +233,51 @@ class SettingsTile extends StatelessWidget {
             : null,
       );
     } else if (_tileType == _SettingsTileType.sliderTile) {
-      return ListTile(
-        title: Slider(
-          value: sliderValue ?? 0,
-          min: sliderMin ?? 0,
-          max: sliderMax ?? 1,
-          onChangeStart: sliderOnChangeStart,
-          onChangeEnd: sliderOnChangeEnd,
-          onChanged: sliderOnChanged,
-        ),
-        subtitle: subtitle != null
-            ? Text(
-                subtitle!,
-                style: subtitleTextStyle,
-                maxLines: subtitleMaxLines,
+      if (title.isNotEmpty) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0, left: 72.0),
+              child: Text(
+                title,
+                style: titleTextStyle,
+                maxLines: titleMaxLines,
                 overflow: TextOverflow.ellipsis,
-              )
-            : null,
-        leading: leading,
-        enabled: enabled,
-        trailing: trailing,
-        onTap: onTapFunction(context) as void Function()?,
-      );
+              ),
+            ),
+            ListTile(
+              title: Slider(
+                value: sliderValue ?? 0,
+                min: sliderMin ?? 0,
+                max: sliderMax ?? 1,
+                onChangeStart: sliderOnChangeStart,
+                onChangeEnd: sliderOnChangeEnd,
+                onChanged: sliderOnChanged,
+              ),
+              leading: leading,
+              enabled: enabled,
+              trailing: trailing,
+              onTap: onTapFunction(context) as void Function()?,
+            ),
+          ],
+        );
+      } else {
+        return ListTile(
+          title: Slider(
+            value: sliderValue ?? 0,
+            min: sliderMin ?? 0,
+            max: sliderMax ?? 1,
+            onChangeStart: sliderOnChangeStart,
+            onChangeEnd: sliderOnChangeEnd,
+            onChanged: sliderOnChanged,
+          ),
+          leading: leading,
+          enabled: enabled,
+          trailing: trailing,
+          onTap: onTapFunction(context) as void Function()?,
+        );
+      }
     } else {
       return ListTile(
         title: Text(title, style: titleTextStyle),

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/cupertino_settings_item.dart';
+import 'package:settings_ui/src/item_type/settings_slider.dart';
 
 import 'defines.dart';
 
@@ -25,17 +26,7 @@ class SettingsTile extends StatelessWidget {
   final TextStyle? subtitleTextStyle;
   final Color? switchActiveColor;
   final _SettingsTileType _tileType;
-
-  // Values for Slider
-  final double? sliderValue;
-  final ValueChanged<double>? sliderOnChanged;
-  final ValueChanged<double>? sliderOnChangeStart;
-  final ValueChanged<double>? sliderOnChangeEnd;
-  final double? sliderMin;
-  final double? sliderMax;
-  final int? sliderDivisions;
-  final Color? sliderActiveColor;
-  final Color? sliderThumbColor;
+  final SettingsSlider? settingsSlider;
 
   const SettingsTile({
     Key? key,
@@ -53,15 +44,7 @@ class SettingsTile extends StatelessWidget {
     this.enabled = true,
     this.onPressed,
     this.switchActiveColor,
-    this.sliderValue,
-    this.sliderOnChanged,
-    this.sliderOnChangeStart,
-    this.sliderOnChangeEnd,
-    this.sliderMin,
-    this.sliderMax,
-    this.sliderDivisions,
-    this.sliderActiveColor,
-    this.sliderThumbColor,
+    this.settingsSlider,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -69,30 +52,22 @@ class SettingsTile extends StatelessWidget {
         assert(subtitleMaxLines == null || subtitleMaxLines > 0),
         super(key: key);
 
-  const SettingsTile.switchTile({
-    Key? key,
-    required this.title,
-    this.titleMaxLines,
-    this.subtitle,
-    this.subtitleMaxLines,
-    this.leading,
-    this.enabled = true,
-    this.trailing,
-    required this.onToggle,
-    required this.switchValue,
-    this.titleTextStyle,
-    this.subtitleTextStyle,
-    this.switchActiveColor,
-    this.sliderValue,
-    this.sliderOnChanged,
-    this.sliderOnChangeStart,
-    this.sliderOnChangeEnd,
-    this.sliderMin,
-    this.sliderMax,
-    this.sliderDivisions,
-    this.sliderActiveColor,
-    this.sliderThumbColor,
-  })  : _tileType = _SettingsTileType.switchTile,
+  const SettingsTile.switchTile(
+      {Key? key,
+      required this.title,
+      this.titleMaxLines,
+      this.subtitle,
+      this.subtitleMaxLines,
+      this.leading,
+      this.enabled = true,
+      this.trailing,
+      required this.onToggle,
+      required this.switchValue,
+      this.titleTextStyle,
+      this.subtitleTextStyle,
+      this.switchActiveColor,
+      this.settingsSlider})
+      : _tileType = _SettingsTileType.switchTile,
         onTap = null,
         onPressed = null,
         iosChevron = null,
@@ -107,15 +82,7 @@ class SettingsTile extends StatelessWidget {
     this.leading,
     this.enabled = true,
     this.trailing,
-    @required this.sliderValue,
-    @required this.sliderOnChanged,
-    this.sliderOnChangeStart,
-    this.sliderOnChangeEnd,
-    this.sliderMin = 0.0,
-    this.sliderMax = 1.0,
-    this.sliderDivisions,
-    this.sliderActiveColor,
-    this.sliderThumbColor = CupertinoColors.white,
+    required this.settingsSlider,
     this.titleTextStyle,
     this.subtitleTextStyle,
     this.switchActiveColor,
@@ -130,12 +97,6 @@ class SettingsTile extends StatelessWidget {
         iosChevron = null,
         iosChevronPadding = null,
         assert(titleMaxLines == null || titleMaxLines > 0),
-        assert(sliderValue != null),
-        assert(sliderMin != null),
-        assert(sliderMax != null),
-        assert(sliderValue! >= sliderMin! && sliderValue <= sliderMax!),
-        assert(sliderDivisions == null || sliderDivisions > 0),
-        assert(sliderThumbColor != null),
         super(key: key);
 
   @override
@@ -173,15 +134,6 @@ class SettingsTile extends StatelessWidget {
         subtitleTextStyle: subtitleTextStyle,
         valueTextStyle: subtitleTextStyle,
         trailing: trailing,
-        sliderValue: sliderValue,
-        sliderMax: sliderMax,
-        sliderMin: sliderMin,
-        sliderThumbColor: sliderThumbColor,
-        sliderActiveColor: sliderActiveColor,
-        sliderOnChangeStart: sliderOnChangeStart,
-        sliderOnChangeEnd: sliderOnChangeEnd,
-        sliderOnChanged: sliderOnChanged,
-        sliderDivisions: sliderDivisions,
       );
     } else if (_tileType == _SettingsTileType.switchTile) {
       return CupertinoSettingsItem(
@@ -235,30 +187,30 @@ class SettingsTile extends StatelessWidget {
         ),
         subtitle: subtitle != null
             ? Text(
-          subtitle!,
-          style: subtitleTextStyle,
-          maxLines: subtitleMaxLines,
-          overflow: TextOverflow.ellipsis,
-        )
+                subtitle!,
+                style: subtitleTextStyle,
+                maxLines: subtitleMaxLines,
+                overflow: TextOverflow.ellipsis,
+              )
             : null,
       );
     } else if (_tileType == _SettingsTileType.sliderTile) {
       return ListTile(
         title: Slider(
-          value: sliderValue!,
-          min: sliderMin!,
-          max: sliderMax!,
-          onChangeStart: sliderOnChangeStart,
-          onChangeEnd: sliderOnChangeEnd,
-          onChanged: sliderOnChanged,
+          value: settingsSlider!.value,
+          min: settingsSlider!.min,
+          max: settingsSlider!.max,
+          onChangeStart: settingsSlider!.onChangeStart,
+          onChangeEnd: settingsSlider!.onChangeEnd,
+          onChanged: settingsSlider!.onChanged,
         ),
         subtitle: subtitle != null
             ? Text(
-          subtitle!,
-          style: subtitleTextStyle,
-          maxLines: subtitleMaxLines,
-          overflow: TextOverflow.ellipsis,
-        )
+                subtitle!,
+                style: subtitleTextStyle,
+                maxLines: subtitleMaxLines,
+                overflow: TextOverflow.ellipsis,
+              )
             : null,
         leading: leading,
         enabled: enabled,
@@ -270,11 +222,11 @@ class SettingsTile extends StatelessWidget {
         title: Text(title, style: titleTextStyle),
         subtitle: subtitle != null
             ? Text(
-          subtitle!,
-          style: subtitleTextStyle,
-          maxLines: subtitleMaxLines,
-          overflow: TextOverflow.ellipsis,
-        )
+                subtitle!,
+                style: subtitleTextStyle,
+                maxLines: subtitleMaxLines,
+                overflow: TextOverflow.ellipsis,
+              )
             : null,
         leading: leading,
         enabled: enabled,
@@ -287,11 +239,11 @@ class SettingsTile extends StatelessWidget {
   VoidCallback? onTapFunction(BuildContext context) =>
       onTap != null || onPressed != null
           ? () {
-        if (onPressed != null) {
-          onPressed!.call(context);
-        } else {
-          onTap!.call();
-        }
-      }
+              if (onPressed != null) {
+                onPressed!.call(context);
+              } else {
+                onTap!.call();
+              }
+            }
           : null;
 }


### PR DESCRIPTION
I created #64 and #68, however there were still readability issues. These have been solved by creating a custom slider object. This object can be used for both iOS and Android. Also, by creating a custom object, we can support more kinds of settings objects while maintaining readability in the `SettingsTile` object. 