### PR TITLE
feature: add theme parameter to settings tile & apply flutter_lint suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,37 @@
-# See https://www.dartlang.org/guides/libraries/private-files
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
 
-# Files and directories created by pub
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
 .dart_tool/
+.flutter-plugins
 .packages
+.pub-cache/
 .pub/
-build/
-# If you're building an application, you may want to check-in your pubspec.lock
-pubspec.lock
-example/.flutter-plugins-dependencies
+/build/
 
-# Directory created by dartdoc
-# If you don't generate documentation locally you can remove this line.
-doc/api/
-settings_ui.iml
-.idea
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Exceptions to above rules.
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+.metadata

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,1 @@
-analyzer:
-  enable-experiment:
-    - extension-methods
+include: package:flutter_lints/flutter.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,12 +8,14 @@ void main() {
   runApp(
     DevicePreview(
       enabled: kIsWeb ? false : !kReleaseMode,
-      builder: (_) => MyApp(),
+      builder: (_) => const MyApp(),
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -30,7 +32,7 @@ class MyApp extends StatelessWidget {
         accentColor: Colors.deepPurple,
         brightness: Brightness.dark,
       ),
-      home: SettingsScreen(),
+      home: const SettingsScreen(),
     );
   }
 }

--- a/example/lib/screens/languages_screen.dart
+++ b/example/lib/screens/languages_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:settings_ui/settings_ui.dart';
 
 class LanguagesScreen extends StatefulWidget {
+  const LanguagesScreen({Key? key}) : super(key: key);
   @override
   _LanguagesScreenState createState() => _LanguagesScreenState();
 }
@@ -12,7 +13,7 @@ class _LanguagesScreenState extends State<LanguagesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Languages')),
+      appBar: AppBar(title: const Text('Languages')),
       body: SettingsList(
         sections: [
           SettingsSection(tiles: [
@@ -52,8 +53,8 @@ class _LanguagesScreenState extends State<LanguagesScreen> {
 
   Widget trailingWidget(int index) {
     return (languageIndex == index)
-        ? Icon(Icons.check, color: Colors.blue)
-        : Icon(null);
+        ? const Icon(Icons.check, color: Colors.blue)
+        : const Icon(null);
   }
 
   void changeLanguage(int index) {

--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:settings_ui/settings_ui.dart';
 import 'languages_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({Key? key}) : super(key: key);
   @override
   _SettingsScreenState createState() => _SettingsScreenState();
 }
@@ -15,7 +16,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Settings UI')),
+      appBar: AppBar(title: const Text('Settings UI')),
       body: buildSettingsList(),
     );
   }
@@ -29,17 +30,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
             SettingsTile(
               title: 'Language',
               subtitle: 'English',
-              leading: Icon(Icons.language),
+              leading: const Icon(Icons.language),
               onPressed: (context) {
                 Navigator.of(context).push(MaterialPageRoute(
-                  builder: (_) => LanguagesScreen(),
+                  builder: (_) => const LanguagesScreen(),
                 ));
               },
             ),
             CustomTile(
               child: Container(
-                color: Color(0xFFEFEFF4),
-                padding: EdgeInsetsDirectional.only(
+                color: const Color(0xFFEFEFF4),
+                padding: const EdgeInsetsDirectional.only(
                   start: 14,
                   top: 12,
                   bottom: 30,
@@ -56,7 +57,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
               ),
             ),
-            SettingsTile(
+            const SettingsTile(
               title: 'Environment',
               subtitle: 'Production',
               leading: Icon(Icons.cloud_queue),
@@ -65,7 +66,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         SettingsSection(
           title: 'Account',
-          tiles: [
+          tiles: const [
             SettingsTile(title: 'Phone number', leading: Icon(Icons.phone)),
             SettingsTile(title: 'Email', leading: Icon(Icons.email)),
             SettingsTile(title: 'Sign out', leading: Icon(Icons.exit_to_app)),
@@ -76,8 +77,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
           tiles: [
             SettingsTile.switchTile(
               title: 'Lock app in background',
-              theme: SettingsTileTheme(tileColor: Colors.green),
-              leading: Icon(Icons.phonelink_lock),
+              theme: const SettingsTileTheme(tileColor: Colors.green),
+              leading: const Icon(Icons.phonelink_lock),
               switchValue: lockInBackground,
               onToggle: (bool value) {
                 setState(() {
@@ -89,20 +90,20 @@ class _SettingsScreenState extends State<SettingsScreen> {
             SettingsTile.switchTile(
               title: 'Use fingerprint',
               subtitle: 'Allow application to access stored fingerprint IDs.',
-              leading: Icon(Icons.fingerprint),
+              leading: const Icon(Icons.fingerprint),
               onToggle: (bool value) {},
               switchValue: false,
             ),
             SettingsTile.switchTile(
               title: 'Change password',
-              leading: Icon(Icons.lock),
+              leading: const Icon(Icons.lock),
               switchValue: true,
               onToggle: (bool value) {},
             ),
             SettingsTile.switchTile(
               title: 'Enable Notifications',
               enabled: notificationsEnabled,
-              leading: Icon(Icons.notifications_active),
+              leading: const Icon(Icons.notifications_active),
               switchValue: true,
               onToggle: (value) {},
             ),
@@ -110,7 +111,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
         SettingsSection(
           title: 'Misc',
-          tiles: [
+          tiles: const [
             SettingsTile(
                 title: 'Terms of Service', leading: Icon(Icons.description)),
             SettingsTile(
@@ -127,10 +128,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   'assets/settings.png',
                   height: 50,
                   width: 50,
-                  color: Color(0xFF777777),
+                  color: const Color(0xFF777777),
                 ),
               ),
-              Text(
+              const Text(
                 'Version: 2.4.0 (287)',
                 style: TextStyle(color: Color(0xFF777777)),
               ),

--- a/example/lib/screens/settings_screen.dart
+++ b/example/lib/screens/settings_screen.dart
@@ -76,6 +76,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           tiles: [
             SettingsTile.switchTile(
               title: 'Lock app in background',
+              theme: SettingsTileTheme(tileColor: Colors.green),
               leading: Icon(Icons.phonelink_lock),
               switchValue: lockInBackground,
               onToggle: (bool value) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,7 @@
 name: example
 description: A new Flutter project.
 version: 1.0.0+1
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
@@ -8,14 +9,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^1.0.2
-  device_preview: ^0.6.2-beta
+  cupertino_icons: ^1.0.3
+  device_preview: ^0.7.4
   settings_ui:
     path: ../
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/lib/settings_ui.dart
+++ b/lib/settings_ui.dart
@@ -4,3 +4,4 @@ export 'package:settings_ui/src/settings_section.dart';
 export 'package:settings_ui/src/settings_tile.dart';
 export 'package:settings_ui/src/settings_list.dart';
 export 'package:settings_ui/src/custom_section.dart';
+export 'package:settings_ui/src/settings_tile_theme.dart';

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -10,11 +10,12 @@ enum SettingsItemType {
   modal,
 }
 
-typedef void PressOperationCallback();
+typedef PressOperationCallback = void Function();
 
 class CupertinoSettingsItem extends StatefulWidget {
   const CupertinoSettingsItem(
-      {required this.type,
+      {Key? key,
+        required this.type,
       this.label,
       this.labelWidget,
       this.labelMaxLines,
@@ -38,7 +39,8 @@ class CupertinoSettingsItem extends StatefulWidget {
       this.switchActiveColor,
       this.listTileTheme})
       : assert(labelMaxLines == null || labelMaxLines > 0),
-        assert(subtitleMaxLines == null || subtitleMaxLines > 0);
+        assert(subtitleMaxLines == null || subtitleMaxLines > 0),
+        super(key: key);
 
   final String? label;
   final Widget? labelWidget;
@@ -65,7 +67,7 @@ class CupertinoSettingsItem extends StatefulWidget {
   final SettingsTileTheme? listTileTheme;
 
   @override
-  State<StatefulWidget> createState() => new CupertinoSettingsItemState();
+  State<StatefulWidget> createState() => CupertinoSettingsItemState();
 }
 
 class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
@@ -94,7 +96,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       horizontalTitleGap: widget.listTileTheme?.horizontalTitleGap,
       minVerticalPadding: widget.listTileTheme?.minVerticalPadding,
       minLeadingWidth: widget.listTileTheme?.minLeadingWidth,
-      child: SizedBox.shrink(),
+      child: const SizedBox.shrink(),
     );
 
     final ListTileTheme tileTheme = listTileThemes ?? ListTileTheme.of(context);
@@ -157,7 +159,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
                 maxLines: widget.subtitleMaxLines,
                 overflow: TextOverflow.ellipsis,
                 style: widget.subtitleTextStyle ??
-                    TextStyle(
+                    const TextStyle(
                       fontSize: 12.0,
                       letterSpacing: -0.2,
                     ),
@@ -179,7 +181,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     switch (widget.type) {
       case SettingsItemType.toggle:
         rowChildren
-          ..add(
+          .add(
             Padding(
               padding: const EdgeInsetsDirectional.only(end: 11.0),
               child: CupertinoSwitch(
@@ -213,7 +215,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
                       overflow: TextOverflow.ellipsis,
                       textAlign: TextAlign.end,
                       style: widget.valueTextStyle ??
-                          TextStyle(
+                          const TextStyle(
                             color: CupertinoColors.inactiveGray,
                             fontSize: 16,
                           ),
@@ -317,7 +319,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
       child: Container(
         decoration: BoxDecoration(
           borderRadius:
-              isLargeScreen ? BorderRadius.all(Radius.circular(20)) : null,
+              isLargeScreen ? const BorderRadius.all(Radius.circular(20)) : null,
           color: tileTheme.tileColor ?? calculateBackgroundColor(context),
         ),
         height: widget.subtitle == null && widget.subtitleWidget == null

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:settings_ui/src/settings_tile_theme.dart';
 
 import 'colors.dart';
 import 'defines.dart';
@@ -12,30 +13,31 @@ enum SettingsItemType {
 typedef void PressOperationCallback();
 
 class CupertinoSettingsItem extends StatefulWidget {
-  const CupertinoSettingsItem({
-    required this.type,
-    this.label,
-    this.labelWidget,
-    this.labelMaxLines,
-    this.subtitle,
-    this.subtitleWidget,
-    this.subtitleMaxLines,
-    this.leading,
-    this.trailing,
-    this.iosChevron = defaultCupertinoForwardIcon,
-    this.iosChevronPadding = defaultCupertinoForwardPadding,
-    this.value,
-    this.valueWidget,
-    this.hasDetails = false,
-    this.enabled = true,
-    this.onPress,
-    this.switchValue = false,
-    this.onToggle,
-    this.labelTextStyle,
-    this.subtitleTextStyle,
-    this.valueTextStyle,
-    this.switchActiveColor,
-  })  : assert(labelMaxLines == null || labelMaxLines > 0),
+  const CupertinoSettingsItem(
+      {required this.type,
+      this.label,
+      this.labelWidget,
+      this.labelMaxLines,
+      this.subtitle,
+      this.subtitleWidget,
+      this.subtitleMaxLines,
+      this.leading,
+      this.trailing,
+      this.iosChevron = defaultCupertinoForwardIcon,
+      this.iosChevronPadding = defaultCupertinoForwardPadding,
+      this.value,
+      this.valueWidget,
+      this.hasDetails = false,
+      this.enabled = true,
+      this.onPress,
+      this.switchValue = false,
+      this.onToggle,
+      this.labelTextStyle,
+      this.subtitleTextStyle,
+      this.valueTextStyle,
+      this.switchActiveColor,
+      this.listTileTheme})
+      : assert(labelMaxLines == null || labelMaxLines > 0),
         assert(subtitleMaxLines == null || subtitleMaxLines > 0);
 
   final String? label;
@@ -60,6 +62,7 @@ class CupertinoSettingsItem extends StatefulWidget {
   final TextStyle? subtitleTextStyle;
   final TextStyle? valueTextStyle;
   final Color? switchActiveColor;
+  final SettingsTileTheme? listTileTheme;
 
   @override
   State<StatefulWidget> createState() => new CupertinoSettingsItemState();
@@ -77,7 +80,24 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     final isLargeScreen = MediaQuery.of(context).size.width >= 768;
 
     final ThemeData theme = Theme.of(context);
-    final ListTileTheme tileTheme = ListTileTheme.of(context);
+    final ListTileTheme? listTileThemes = ListTileTheme(
+      dense: widget.listTileTheme?.dense ?? ListTileTheme.of(context).dense,
+      shape: widget.listTileTheme?.shape,
+      style: widget.listTileTheme?.style ?? ListTileTheme.of(context).style,
+      selectedColor: widget.listTileTheme?.selectedColor,
+      iconColor: widget.listTileTheme?.iconColor,
+      textColor: widget.listTileTheme?.textColor,
+      contentPadding: widget.listTileTheme?.contentPadding,
+      tileColor: widget.listTileTheme?.tileColor,
+      selectedTileColor: widget.listTileTheme?.selectedTileColor,
+      enableFeedback: widget.listTileTheme?.enableFeedback,
+      horizontalTitleGap: widget.listTileTheme?.horizontalTitleGap,
+      minVerticalPadding: widget.listTileTheme?.minVerticalPadding,
+      minLeadingWidth: widget.listTileTheme?.minLeadingWidth,
+      child: SizedBox.shrink(),
+    );
+
+    final ListTileTheme tileTheme = listTileThemes ?? ListTileTheme.of(context);
 
     final iconThemeData = IconThemeData(
       color: widget.enabled
@@ -97,8 +117,8 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     if (leadingIcon != null) {
       rowChildren.add(
         Padding(
-          padding: const EdgeInsetsDirectional.only(
-            start: 15.0,
+          padding: EdgeInsetsDirectional.only(
+            start: tileTheme.minLeadingWidth ?? 15.0,
           ),
           child: leadingIcon,
         ),
@@ -113,9 +133,10 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
             overflow: TextOverflow.ellipsis,
             style: widget.labelTextStyle ??
                 TextStyle(
-                  fontSize: 16,
-                  color: widget.enabled ? null : CupertinoColors.inactiveGray,
-                ),
+                    fontSize: 16,
+                    color: !widget.enabled
+                        ? CupertinoColors.inactiveGray
+                        : widget.listTileTheme?.textColor),
           );
     } else {
       titleSection = Column(
@@ -297,7 +318,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
         decoration: BoxDecoration(
           borderRadius:
               isLargeScreen ? BorderRadius.all(Radius.circular(20)) : null,
-          color: calculateBackgroundColor(context),
+          color: tileTheme.tileColor ?? calculateBackgroundColor(context),
         ),
         height: widget.subtitle == null && widget.subtitleWidget == null
             ? 44.0
@@ -319,9 +340,9 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
               : iosTileDarkColor;
 
   Color? _iconColor(ThemeData theme, ListTileTheme tileTheme) {
-    if (tileTheme.selectedColor != null) {
-      return tileTheme.selectedColor;
-    }
+    // if (tileTheme.selectedColor != null) {
+    //   return tileTheme.selectedColor;
+    // }
 
     if (tileTheme.iconColor != null) {
       return tileTheme.iconColor;

--- a/lib/src/cupertino_settings_section.dart
+++ b/lib/src/cupertino_settings_section.dart
@@ -8,10 +8,11 @@ import 'defines.dart';
 class CupertinoSettingsSection extends StatelessWidget {
   const CupertinoSettingsSection(
     this.items, {
+      Key? key,
     this.header,
     this.headerPadding = defaultTitlePadding,
     this.footer,
-  });
+  }) : super(key: key);
 
   final List<Widget> items;
 
@@ -63,7 +64,7 @@ class CupertinoSettingsSection extends StatelessWidget {
     columnChildren.add(largeScreen
         ? Container(
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(20)),
+              borderRadius: const BorderRadius.all(Radius.circular(20)),
               color: Theme.of(context).brightness == Brightness.light
                   ? CupertinoColors.white
                   : iosTileDarkColor,
@@ -78,12 +79,12 @@ class CupertinoSettingsSection extends StatelessWidget {
               color: Theme.of(context).brightness == Brightness.light
                   ? CupertinoColors.white
                   : iosTileDarkColor,
-              border: Border(
-                top: const BorderSide(
+              border: const Border(
+                top: BorderSide(
                   color: borderColor,
                   width: 0.3,
                 ),
-                bottom: const BorderSide(
+                bottom: BorderSide(
                   color: borderColor,
                   width: 0.3,
                 ),
@@ -97,13 +98,13 @@ class CupertinoSettingsSection extends StatelessWidget {
 
     if (footer != null) {
       columnChildren.add(DefaultTextStyle(
-        style: TextStyle(
+        style: const TextStyle(
           color: groupSubtitle,
           fontSize: 13.0,
           letterSpacing: -0.08,
         ),
         child: Padding(
-          padding: EdgeInsets.only(
+          padding: const EdgeInsets.only(
             left: 15.0,
             right: 15.0,
             top: 7.5,

--- a/lib/src/settings_section.dart
+++ b/lib/src/settings_section.dart
@@ -101,16 +101,16 @@ class SettingsSection extends AbstractSection {
           child: subtitle,
         ),
       ListView.separated(
-        physics: NeverScrollableScrollPhysics(),
+        physics: const NeverScrollableScrollPhysics(),
         shrinkWrap: true,
         itemCount: tiles!.length,
         separatorBuilder: (BuildContext context, int index) =>
-            Divider(height: 1),
+            const Divider(height: 1),
         itemBuilder: (BuildContext context, int index) {
           return tiles![index];
         },
       ),
-      if (showBottomDivider) Divider(height: 1)
+      if (showBottomDivider) const Divider(height: 1)
     ]);
   }
 }

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -241,10 +241,10 @@ class SettingsTile extends AbstractTile {
 
 class CustomTile extends AbstractTile {
   final Widget child;
-
-  CustomTile({
+  const CustomTile({
+    Key? key,
     required this.child,
-  });
+  }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return child;

--- a/lib/src/settings_tile.dart
+++ b/lib/src/settings_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/src/cupertino_settings_item.dart';
+import 'package:settings_ui/src/settings_tile_theme.dart';
 
 import 'defines.dart';
 
@@ -32,6 +33,9 @@ class SettingsTile extends AbstractTile {
   final _SettingsTileType _tileType;
   final TargetPlatform? platform;
 
+  /// iOS only supports iconColor, textColor & tileColor
+  final SettingsTileTheme? theme;
+
   const SettingsTile({
     Key? key,
     this.title,
@@ -51,6 +55,7 @@ class SettingsTile extends AbstractTile {
     this.onPressed,
     this.switchActiveColor,
     this.platform,
+    this.theme,
   })  : _tileType = _SettingsTileType.simple,
         onToggle = null,
         switchValue = null,
@@ -75,6 +80,7 @@ class SettingsTile extends AbstractTile {
     this.subtitleTextStyle,
     this.switchActiveColor,
     this.platform,
+    this.theme,
   })  : _tileType = _SettingsTileType.switchTile,
         onTap = null,
         onPressed = null,
@@ -121,6 +127,7 @@ class SettingsTile extends AbstractTile {
         subtitleTextStyle: subtitleTextStyle,
         valueTextStyle: subtitleTextStyle,
         trailing: trailing,
+        listTileTheme: theme,
       );
     } else {
       return CupertinoSettingsItem(
@@ -141,50 +148,81 @@ class SettingsTile extends AbstractTile {
         labelTextStyle: titleTextStyle,
         subtitleTextStyle: subtitleTextStyle,
         valueTextStyle: subtitleTextStyle,
+        listTileTheme: theme,
       );
     }
   }
 
   Widget androidTile(BuildContext context) {
     if (_tileType == _SettingsTileType.switchTile) {
-      return SwitchListTile(
-        secondary: leading,
-        value: switchValue!,
-        activeColor: switchActiveColor,
-        onChanged: enabled ? onToggle : null,
-        title: titleWidget ??
-            Text(
-              title ?? '',
-              style: titleTextStyle,
-              maxLines: titleMaxLines,
-              overflow: TextOverflow.ellipsis,
-            ),
-        subtitle: subtitleWidget ??
-            (subtitle != null
-                ? Text(
-                    subtitle!,
-                    style: subtitleTextStyle,
-                    maxLines: subtitleMaxLines,
-                    overflow: TextOverflow.ellipsis,
-                  )
-                : null),
+      return ListTileTheme.merge(
+        dense: theme?.dense,
+        shape: theme?.shape,
+        style: theme?.style,
+        selectedColor: theme?.selectedColor,
+        iconColor: theme?.iconColor,
+        textColor: theme?.textColor,
+        contentPadding: theme?.contentPadding,
+        tileColor: theme?.tileColor,
+        selectedTileColor: theme?.selectedTileColor,
+        enableFeedback: theme?.enableFeedback,
+        horizontalTitleGap: theme?.horizontalTitleGap,
+        minVerticalPadding: theme?.minVerticalPadding,
+        minLeadingWidth: theme?.minLeadingWidth,
+        child: SwitchListTile(
+          secondary: leading,
+          value: switchValue!,
+          activeColor: switchActiveColor,
+          onChanged: enabled ? onToggle : null,
+          title: titleWidget ??
+              Text(
+                title ?? '',
+                style: titleTextStyle,
+                maxLines: titleMaxLines,
+                overflow: TextOverflow.ellipsis,
+              ),
+          subtitle: subtitleWidget ??
+              (subtitle != null
+                  ? Text(
+                      subtitle!,
+                      style: subtitleTextStyle,
+                      maxLines: subtitleMaxLines,
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null),
+        ),
       );
     } else {
-      return ListTile(
-        title: titleWidget ?? Text(title ?? '', style: titleTextStyle),
-        subtitle: subtitleWidget ??
-            (subtitle != null
-                ? Text(
-                    subtitle!,
-                    style: subtitleTextStyle,
-                    maxLines: subtitleMaxLines,
-                    overflow: TextOverflow.ellipsis,
-                  )
-                : null),
-        leading: leading,
-        enabled: enabled,
-        trailing: trailing,
-        onTap: onTapFunction(context) as void Function()?,
+      return ListTileTheme.merge(
+        dense: theme?.dense,
+        shape: theme?.shape,
+        style: theme?.style,
+        selectedColor: theme?.selectedColor,
+        iconColor: theme?.iconColor,
+        textColor: theme?.textColor,
+        contentPadding: theme?.contentPadding,
+        tileColor: theme?.tileColor,
+        selectedTileColor: theme?.selectedTileColor,
+        enableFeedback: theme?.enableFeedback,
+        horizontalTitleGap: theme?.horizontalTitleGap,
+        minVerticalPadding: theme?.minVerticalPadding,
+        minLeadingWidth: theme?.minLeadingWidth,
+        child: ListTile(
+          title: titleWidget ?? Text(title ?? '', style: titleTextStyle),
+          subtitle: subtitleWidget ??
+              (subtitle != null
+                  ? Text(
+                      subtitle!,
+                      style: subtitleTextStyle,
+                      maxLines: subtitleMaxLines,
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null),
+          leading: leading,
+          enabled: enabled,
+          trailing: trailing,
+          onTap: onTapFunction(context) as void Function()?,
+        ),
       );
     }
   }

--- a/lib/src/settings_tile_theme.dart
+++ b/lib/src/settings_tile_theme.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+class SettingsTileTheme {
+  /// If true then [ListTile]s will have the vertically dense layout.
+  ///
+  /// Only Android
+  final bool? dense;
+
+  /// {@template flutter.material.ListTileTheme.shape}
+  /// If specified, [shape] defines the [ListTile]'s shape.
+  /// {@endtemplate}
+  ///
+  /// Only Android
+  final ShapeBorder? shape;
+
+  /// If specified, [style] defines the font used for [ListTile] titles.
+  ///
+  /// Only Android
+  final ListTileStyle? style;
+
+  /// If specified, the color used for icons and text when a [ListTile] is selected.
+  ///
+  /// Only Android
+  final Color? selectedColor;
+
+  /// If specified, the icon color used for enabled [ListTile]s that are not selected.
+  final Color? iconColor;
+
+  /// If specified, the text color used for enabled [ListTile]s that are not selected.
+  final Color? textColor;
+
+  /// The tile's internal padding.
+  ///
+  /// Insets a [ListTile]'s contents: its [ListTile.leading], [ListTile.title],
+  /// [ListTile.subtitle], and [ListTile.trailing] widgets.
+  ///
+  /// Only Android
+  final EdgeInsetsGeometry? contentPadding;
+
+  /// If specified, defines the background color for `ListTile` when
+  /// [ListTile.selected] is false.
+  ///
+  /// If [ListTile.tileColor] is provided, [tileColor] is ignored.
+  final Color? tileColor;
+
+  /// If specified, defines the background color for `ListTile` when
+  /// [ListTile.selected] is true.
+  ///
+  /// If [ListTile.selectedTileColor] is provided, [selectedTileColor] is ignored.
+  ///
+  /// Only Android
+  final Color? selectedTileColor;
+
+  /// The horizontal gap between the titles and the leading/trailing widgets.
+  ///
+  /// If specified, overrides the default value of [ListTile.horizontalTitleGap].
+  ///
+  /// Only Android
+  final double? horizontalTitleGap;
+
+  /// The minimum padding on the top and bottom of the title and subtitle widgets.
+  ///
+  /// If specified, overrides the default value of [ListTile.minVerticalPadding].
+  ///
+  /// Only Android
+  final double? minVerticalPadding;
+
+  /// The minimum width allocated for the [ListTile.leading] widget.
+  ///
+  /// If specified, overrides the default value of [ListTile.minLeadingWidth].
+  ///
+  /// Only Android
+  final double? minLeadingWidth;
+
+  /// If specified, defines the feedback property for `ListTile`.
+  ///
+  /// If [ListTile.enableFeedback] is provided, [enableFeedback] is ignored.
+  ///
+  /// Only Android
+  final bool? enableFeedback;
+
+  const SettingsTileTheme({
+    this.tileColor,
+    this.contentPadding,
+    this.shape,
+    this.selectedTileColor,
+    this.dense,
+    this.style,
+    this.selectedColor,
+    this.iconColor,
+    this.textColor,
+    this.horizontalTitleGap,
+    this.minVerticalPadding,
+    this.minLeadingWidth,
+    this.enableFeedback,
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.0
+  flutter_lints: ^1.0.4
 
 flutter:


### PR DESCRIPTION
This PR will add possibilities to give a tile different colors. See `settings_tile_theme.dart` for all parameters.

This PR also migrates from deprecated (and not used) pedantic to flutter_lints, and applies all suggestions.