### PR TITLE
Techdebt, which fixes a syntax error with most recent Flutter sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.2] - [Oct 19, 2021]
+* Bump up dependencies versions
+* Remove types, where possible, of final variables (fixes a bug with recent Cupertino sources)
+
 ## [1.0.1] - [Jul 28, 2021]
 * Allow manual platform style selection
 * Fixed iOS Title text getting cut off in version 1.0.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 In your pubspec.yaml
 ```yaml
 dependencies:
-  settings_ui: ^1.0.1
+  settings_ui: ^1.0.2
 ```
 ```dart
 import 'package:settings_ui/settings_ui.dart';

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,15 +1,15 @@
 name: example
-description: A new Flutter project.
+description: Example project for settings-ui package.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^1.0.2
-  device_preview: ^0.6.2-beta
+  cupertino_icons: ^1.0.3
+  device_preview: ^0.7.4
   settings_ui:
     path: ../
 

--- a/lib/src/cupertino_settings_item.dart
+++ b/lib/src/cupertino_settings_item.dart
@@ -76,8 +76,8 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
     /// The width of iPad. This is used to make circular borders on iPad and web
     final isLargeScreen = MediaQuery.of(context).size.width >= 768;
 
-    final ThemeData theme = Theme.of(context);
-    final ListTileTheme tileTheme = ListTileTheme.of(context);
+    final theme = Theme.of(context);
+    final tileTheme = ListTileTheme.of(context);
 
     final iconThemeData = IconThemeData(
       color: widget.enabled
@@ -165,7 +165,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
                 value: widget.switchValue!,
                 activeColor: widget.enabled
                     ? (widget.switchActiveColor ??
-                        Theme.of(context).accentColor)
+                        Theme.of(context).colorScheme.secondary)
                     : CupertinoColors.inactiveGray,
                 onChanged: !widget.enabled
                     ? null
@@ -202,7 +202,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
           );
         }
 
-        final List<Widget> endRowChildren = [];
+        final endRowChildren = <Widget>[];
         if (widget.trailing != null) {
           endRowChildren.add(
             Padding(
@@ -318,7 +318,7 @@ class CupertinoSettingsItemState extends State<CupertinoSettingsItem> {
               ? iosPressedTileColorDark
               : iosTileDarkColor;
 
-  Color? _iconColor(ThemeData theme, ListTileTheme tileTheme) {
+  Color? _iconColor(ThemeData theme, ListTileThemeData tileTheme) {
     if (tileTheme.selectedColor != null) {
       return tileTheme.selectedColor;
     }

--- a/lib/src/cupertino_settings_section.dart
+++ b/lib/src/cupertino_settings_section.dart
@@ -21,7 +21,7 @@ class CupertinoSettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> columnChildren = [];
+    final columnChildren = <Widget>[];
     if (header != null) {
       columnChildren.add(DefaultTextStyle(
         style: TextStyle(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: settings_ui
 description: Create native settings for Flutter app in minutes. Use single interfaces to build
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/yako-dev/flutter-settings-ui
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.0
+  pedantic: ^1.11.1
 
 flutter:


### PR DESCRIPTION
If you're using the most recent Flutter sources `(master` channel), you cannot use the package due to a syntax error in the source code of the package. This is due to changes made in Flutter's Cupertino sources.

This pr addresses this problem, and also removes types of `final` variables.