### PR TITLE
Feature: iOS description inline with settingsTile

### DIFF
--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/lib/src/sections/platforms/ios_settings_section.dart
+++ b/lib/src/sections/platforms/ios_settings_section.dart
@@ -66,7 +66,8 @@ class IOSSettingsSection extends StatelessWidget {
         if (index == 0 ||
             (index > 0 &&
                 tiles[index - 1] is SettingsTile &&
-                (tiles[index - 1] as SettingsTile).description != null)) {
+                (tiles[index - 1] as SettingsTile).description != null &&
+                !(tiles[index - 1] as SettingsTile).descriptionInlineIos)) {
           enableTop = true;
         }
 
@@ -75,7 +76,8 @@ class IOSSettingsSection extends StatelessWidget {
         if (index == tiles.length - 1 ||
             (index < tiles.length &&
                 tile is SettingsTile &&
-                (tile).description != null)) {
+                (tile).description != null &&
+                !tile.descriptionInlineIos)) {
           enableBottom = true;
         }
 

--- a/lib/src/tiles/platforms/ios_settings_tile.dart
+++ b/lib/src/tiles/platforms/ios_settings_tile.dart
@@ -15,6 +15,7 @@ class IOSSettingsTile extends StatefulWidget {
     required this.activeSwitchColor,
     required this.enabled,
     required this.trailing,
+    required this.descriptionInline,
     Key? key,
   }) : super(key: key);
 
@@ -29,6 +30,7 @@ class IOSSettingsTile extends StatefulWidget {
   final bool enabled;
   final Color? activeSwitchColor;
   final Widget? trailing;
+  final bool descriptionInline;
 
   @override
   _IOSSettingsTileState createState() => _IOSSettingsTileState();
@@ -51,7 +53,7 @@ class _IOSSettingsTileState extends State<IOSSettingsTile> {
             theme: theme,
             additionalInfo: additionalInfo,
           ),
-          if (widget.description != null)
+          if (widget.description != null && !widget.descriptionInline)
             buildDescription(
               context: context,
               theme: theme,
@@ -225,27 +227,55 @@ class _IOSSettingsTileState extends State<IOSSettingsTile> {
                     child: Row(
                       children: [
                         Expanded(
-                          child: Padding(
-                            padding: EdgeInsetsDirectional.only(
-                              top: 12.5 * scaleFactor,
-                              bottom: 12.5 * scaleFactor,
-                            ),
-                            child: DefaultTextStyle(
-                              style: TextStyle(
-                                color: widget.enabled
-                                    ? theme.themeData.settingsTileTextColor
-                                    : theme.themeData.inactiveTitleColor,
-                                fontSize: 16,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: EdgeInsetsDirectional.only(
+                                  top: widget.description != null &&
+                                          widget.descriptionInline
+                                      ? 6
+                                      : 12.5 * scaleFactor,
+                                  bottom: widget.description != null &&
+                                          widget.descriptionInline
+                                      ? 3
+                                      : 12.5 * scaleFactor,
+                                ),
+                                child: DefaultTextStyle(
+                                  style: TextStyle(
+                                    color: widget.enabled
+                                        ? theme.themeData.settingsTileTextColor
+                                        : theme.themeData.inactiveTitleColor,
+                                    fontSize: 16,
+                                  ),
+                                  child: widget.title!,
+                                ),
                               ),
-                              child: widget.title!,
-                            ),
+                              if (widget.description != null &&
+                                  widget.descriptionInline)
+                                Padding(
+                                  padding: EdgeInsets.only(bottom: 6),
+                                  child: Row(
+                                    children: [
+                                      DefaultTextStyle(
+                                        style: TextStyle(
+                                          color: theme.themeData.titleTextColor,
+                                          fontSize: 13,
+                                        ),
+                                        child: widget.description!,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
                         buildTrailing(context: context, theme: theme),
                       ],
                     ),
                   ),
-                  if (widget.description == null &&
+                  if ((widget.description == null ||
+                          widget.descriptionInline) &&
                       additionalInfo.needToShowDivider)
                     Divider(
                       height: 0,

--- a/lib/src/tiles/settings_tile.dart
+++ b/lib/src/tiles/settings_tile.dart
@@ -15,6 +15,7 @@ class SettingsTile extends AbstractSettingsTile {
     this.value,
     required this.title,
     this.description,
+    this.descriptionInlineIos = false,
     this.onPressed,
     this.enabled = true,
     Key? key,
@@ -31,6 +32,7 @@ class SettingsTile extends AbstractSettingsTile {
     this.value,
     required this.title,
     this.description,
+    this.descriptionInlineIos = false,
     this.onPressed,
     this.enabled = true,
     Key? key,
@@ -44,6 +46,7 @@ class SettingsTile extends AbstractSettingsTile {
   SettingsTile.switchTile({
     required this.initialValue,
     required this.onToggle,
+    this.descriptionInlineIos = false,
     this.activeSwitchColor,
     this.leading,
     this.trailing,
@@ -68,6 +71,8 @@ class SettingsTile extends AbstractSettingsTile {
 
   /// The widget at the bottom of the [title]
   final Widget? description;
+
+  final bool descriptionInlineIos;
 
   /// A function that is called by tap on a tile
   final Function(BuildContext context)? onPressed;
@@ -105,6 +110,7 @@ class SettingsTile extends AbstractSettingsTile {
       case DevicePlatform.windows:
         return IOSSettingsTile(
           description: description,
+          descriptionInline: true,
           onPressed: onPressed,
           onToggle: onToggle,
           tileType: tileType,

--- a/lib/src/tiles/settings_tile.dart
+++ b/lib/src/tiles/settings_tile.dart
@@ -72,6 +72,8 @@ class SettingsTile extends AbstractSettingsTile {
   /// The widget at the bottom of the [title]
   final Widget? description;
 
+  /// Whether the description should be inline in the settingsTile or not.
+  /// default: false
   final bool descriptionInlineIos;
 
   /// A function that is called by tap on a tile


### PR DESCRIPTION
With the new design the description is under the settingsTile, which causes the settingsSection to break up.
![Simulator Screen Shot - iPhone 13 - 2022-07-21 at 16 29 14](https://user-images.githubusercontent.com/20091319/180241068-e1c9b7c0-ff0a-406a-b73e-4917aea09ad1.png)

By adding a inline function, we can provide a simple description inline with the settingsTile without breaking up the settingsSection:

![Simulator Screen Shot - iPhone 13 - 2022-07-21 at 16 29 29](https://user-images.githubusercontent.com/20091319/180241181-d876acfb-07ed-4502-ae31-42e464bcb8d8.png)

