### PR TITLE
Add expandable tile

### DIFF
--- a/lib/src/tiles/platforms/android_settings_tile.dart
+++ b/lib/src/tiles/platforms/android_settings_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:settings_ui/settings_ui.dart';
 
-class AndroidSettingsTile extends StatelessWidget {
+class AndroidSettingsTile extends StatefulWidget {
   const AndroidSettingsTile({
     required this.tileType,
     required this.leading,
@@ -14,6 +14,11 @@ class AndroidSettingsTile extends StatelessWidget {
     required this.activeSwitchColor,
     required this.enabled,
     required this.trailing,
+    required this.expandDuration,
+    required this.contractDuration,
+    required this.expandCurve,
+    required this.contractCurve,
+    required this.builder,
     Key? key,
   }) : super(key: key);
 
@@ -22,6 +27,11 @@ class AndroidSettingsTile extends StatelessWidget {
   final Widget? title;
   final Widget? description;
   final Function(BuildContext context)? onPressed;
+  final Duration expandDuration;
+  final Duration contractDuration;
+  final Curve expandCurve;
+  final Curve contractCurve;
+  final Widget Function(VoidCallback close)? builder;
   final Function(bool value)? onToggle;
   final Widget? value;
   final bool initialValue;
@@ -30,130 +40,205 @@ class AndroidSettingsTile extends StatelessWidget {
   final Widget? trailing;
 
   @override
+  State<AndroidSettingsTile> createState() => _AndroidSettingsTileState();
+}
+
+class _AndroidSettingsTileState extends State<AndroidSettingsTile>
+    with TickerProviderStateMixin {
+  late final AnimationController controller;
+  late final Animation<double> animation;
+
+  bool get isExpanding =>
+      animation.status == AnimationStatus.forward ||
+      animation.status == AnimationStatus.completed;
+
+  @override
+  void initState() {
+    super.initState();
+
+    controller = AnimationController(
+      duration: widget.expandDuration,
+      vsync: this,
+    );
+    animation = CurvedAnimation(
+      parent: controller,
+      curve: widget.expandCurve,
+    );
+  }
+
+  expand() {
+    controller.forward();
+  }
+
+  contract() {
+    controller.animateBack(
+      0.0,
+      duration: widget.contractDuration,
+      curve: widget.contractCurve,
+    );
+  }
+
+  toggleContainer() {
+    if (isExpanding) {
+      contract();
+    } else {
+      expand();
+    }
+
+    setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = SettingsTheme.of(context);
     final scaleFactor = MediaQuery.of(context).textScaleFactor;
 
-    final cantShowAnimation = tileType == SettingsTileType.switchTile
-        ? onToggle == null && onPressed == null
-        : onPressed == null;
+    final cantShowAnimation = widget.tileType == SettingsTileType.switchTile
+        ? widget.onToggle == null && widget.onPressed == null
+        : widget.onPressed == null &&
+            widget.tileType != SettingsTileType.expandableTile;
 
     return IgnorePointer(
-      ignoring: !enabled,
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: cantShowAnimation
-              ? null
-              : () {
-                  if (tileType == SettingsTileType.switchTile) {
-                    onToggle?.call(!initialValue);
-                  } else {
-                    onPressed?.call(context);
-                  }
-                },
-          highlightColor: theme.themeData.tileHighlightColor,
-          child: Container(
-            child: Row(
-              children: [
-                if (leading != null)
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(start: 24),
-                    child: IconTheme(
-                      data: IconTheme.of(context).copyWith(
-                        color: enabled
-                            ? theme.themeData.leadingIconsColor
-                            : theme.themeData.inactiveTitleColor,
-                      ),
-                      child: leading!,
-                    ),
-                  ),
-                Expanded(
-                  child: Padding(
-                    padding: EdgeInsetsDirectional.only(
-                      start: 24,
-                      end: 24,
-                      bottom: 19 * scaleFactor,
-                      top: 19 * scaleFactor,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        DefaultTextStyle(
-                          style: TextStyle(
-                            color: enabled
-                                ? theme.themeData.settingsTileTextColor
-                                : theme.themeData.inactiveTitleColor,
-                            fontSize: 18,
-                            fontWeight: FontWeight.w400,
-                          ),
-                          child: title ?? Container(),
-                        ),
-                        if (value != null)
-                          Padding(
-                            padding: EdgeInsets.only(top: 4.0),
-                            child: DefaultTextStyle(
-                              style: TextStyle(
-                                color: enabled
-                                    ? theme.themeData.tileDescriptionTextColor
-                                    : theme.themeData.inactiveSubtitleColor,
-                              ),
-                              child: value!,
-                            ),
-                          )
-                        else if (description != null)
-                          Padding(
-                            padding: EdgeInsets.only(top: 4.0),
-                            child: DefaultTextStyle(
-                              style: TextStyle(
-                                color: enabled
-                                    ? theme.themeData.tileDescriptionTextColor
-                                    : theme.themeData.inactiveSubtitleColor,
-                              ),
-                              child: description!,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
-                if (trailing != null && tileType == SettingsTileType.switchTile)
-                  Row(
-                    children: [
-                      trailing!,
+      ignoring: !widget.enabled,
+      child: Column(
+        children: <Widget>[
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: cantShowAnimation
+                  ? null
+                  : () {
+                      if (widget.tileType == SettingsTileType.switchTile) {
+                        widget.onToggle?.call(!widget.initialValue);
+                      } else if (widget.tileType ==
+                          SettingsTileType.expandableTile) {
+                        toggleContainer();
+                      } else {
+                        widget.onPressed?.call(context);
+                      }
+                    },
+              highlightColor: theme.themeData.tileHighlightColor,
+              child: Container(
+                child: Row(
+                  children: [
+                    if (widget.leading != null)
                       Padding(
-                        padding: const EdgeInsetsDirectional.only(end: 8),
+                        padding: const EdgeInsetsDirectional.only(start: 24),
+                        child: IconTheme(
+                          data: IconTheme.of(context).copyWith(
+                            color: widget.enabled
+                                ? theme.themeData.leadingIconsColor
+                                : theme.themeData.inactiveTitleColor,
+                          ),
+                          child: widget.leading!,
+                        ),
+                      ),
+                    Expanded(
+                      child: Padding(
+                        padding: EdgeInsetsDirectional.only(
+                          start: 24,
+                          end: 24,
+                          bottom: 19 * scaleFactor,
+                          top: 19 * scaleFactor,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            DefaultTextStyle(
+                              style: TextStyle(
+                                color: widget.enabled
+                                    ? theme.themeData.settingsTileTextColor
+                                    : theme.themeData.inactiveTitleColor,
+                                fontSize: 18,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              child: widget.title ?? Container(),
+                            ),
+                            if (widget.value != null)
+                              Padding(
+                                padding: EdgeInsets.only(top: 4.0),
+                                child: DefaultTextStyle(
+                                  style: TextStyle(
+                                    color: widget.enabled
+                                        ? theme
+                                            .themeData.tileDescriptionTextColor
+                                        : theme.themeData.inactiveSubtitleColor,
+                                  ),
+                                  child: widget.value!,
+                                ),
+                              )
+                            else if (widget.description != null)
+                              Padding(
+                                padding: EdgeInsets.only(top: 4.0),
+                                child: DefaultTextStyle(
+                                  style: TextStyle(
+                                    color: widget.enabled
+                                        ? theme
+                                            .themeData.tileDescriptionTextColor
+                                        : theme.themeData.inactiveSubtitleColor,
+                                  ),
+                                  child: widget.description!,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (widget.trailing != null &&
+                        widget.tileType == SettingsTileType.switchTile)
+                      Row(
+                        children: [
+                          widget.trailing!,
+                          Padding(
+                            padding: const EdgeInsetsDirectional.only(end: 8),
+                            child: Switch(
+                              value: widget.initialValue,
+                              onChanged: widget.onToggle,
+                              activeColor: widget.enabled
+                                  ? widget.activeSwitchColor
+                                  : theme.themeData.inactiveTitleColor,
+                            ),
+                          ),
+                        ],
+                      )
+                    else if (widget.tileType == SettingsTileType.switchTile)
+                      Padding(
+                        padding:
+                            const EdgeInsetsDirectional.only(start: 16, end: 8),
                         child: Switch(
-                          value: initialValue,
-                          onChanged: onToggle,
-                          activeColor: enabled
-                              ? activeSwitchColor
+                          value: widget.initialValue,
+                          onChanged: widget.onToggle,
+                          activeColor: widget.enabled
+                              ? widget.activeSwitchColor
                               : theme.themeData.inactiveTitleColor,
                         ),
-                      ),
-                    ],
-                  )
-                else if (tileType == SettingsTileType.switchTile)
-                  Padding(
-                    padding:
-                        const EdgeInsetsDirectional.only(start: 16, end: 8),
-                    child: Switch(
-                      value: initialValue,
-                      onChanged: onToggle,
-                      activeColor: enabled
-                          ? activeSwitchColor
-                          : theme.themeData.inactiveTitleColor,
-                    ),
-                  )
-                else if (trailing != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: trailing!,
-                  )
-              ],
+                      )
+                    else if (widget.trailing != null)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: widget.trailing!,
+                      )
+                    else if (widget.tileType == SettingsTileType.expandableTile)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: AnimatedRotation(
+                          duration: kThemeChangeDuration,
+                          turns: isExpanding ? .5 : 0,
+                          child: const Icon(Icons.arrow_drop_down),
+                        ),
+                      )
+                  ],
+                ),
+              ),
             ),
           ),
-        ),
+          if (widget.tileType == SettingsTileType.expandableTile)
+            SizeTransition(
+              sizeFactor: animation,
+              axis: Axis.vertical,
+              child: widget.builder!(contract),
+            )
+        ],
       ),
     );
   }

--- a/lib/src/tiles/settings_tile.dart
+++ b/lib/src/tiles/settings_tile.dart
@@ -6,7 +6,9 @@ import 'package:settings_ui/src/tiles/platforms/web_settings_tile.dart';
 import 'package:settings_ui/src/utils/platform_utils.dart';
 import 'package:settings_ui/src/utils/settings_theme.dart';
 
-enum SettingsTileType { simpleTile, switchTile, navigationTile }
+enum SettingsTileType { simpleTile, switchTile, navigationTile, expandableTile }
+
+typedef BuilderFunction = Widget Function(VoidCallback close);
 
 class SettingsTile extends AbstractSettingsTile {
   SettingsTile({
@@ -18,12 +20,12 @@ class SettingsTile extends AbstractSettingsTile {
     this.onPressed,
     this.enabled = true,
     Key? key,
-  }) : super(key: key) {
-    onToggle = null;
-    initialValue = null;
-    activeSwitchColor = null;
-    tileType = SettingsTileType.simpleTile;
-  }
+  })  : builder = null,
+        onToggle = null,
+        initialValue = null,
+        activeSwitchColor = null,
+        tileType = SettingsTileType.simpleTile,
+        super(key: key);
 
   SettingsTile.navigation({
     this.leading,
@@ -34,12 +36,12 @@ class SettingsTile extends AbstractSettingsTile {
     this.onPressed,
     this.enabled = true,
     Key? key,
-  }) : super(key: key) {
-    onToggle = null;
-    initialValue = null;
-    activeSwitchColor = null;
-    tileType = SettingsTileType.navigationTile;
-  }
+  })  : builder = null,
+        onToggle = null,
+        initialValue = null,
+        activeSwitchColor = null,
+        tileType = SettingsTileType.navigationTile,
+        super(key: key);
 
   SettingsTile.switchTile({
     required this.initialValue,
@@ -52,10 +54,26 @@ class SettingsTile extends AbstractSettingsTile {
     this.onPressed,
     this.enabled = true,
     Key? key,
-  }) : super(key: key) {
-    value = null;
-    tileType = SettingsTileType.switchTile;
-  }
+  })  : builder = null,
+        value = null,
+        tileType = SettingsTileType.switchTile,
+        super(key: key);
+
+  SettingsTile.expandableTile({
+    required this.title,
+    required this.builder,
+    this.enabled = true,
+    this.leading,
+    this.trailing,
+    this.description,
+    Key? key,
+  })  : initialValue = null,
+        activeSwitchColor = null,
+        onPressed = null,
+        onToggle = null,
+        value = null,
+        tileType = SettingsTileType.expandableTile,
+        super(key: key);
 
   /// The widget at the beginning of the tile
   final Widget? leading;
@@ -72,12 +90,28 @@ class SettingsTile extends AbstractSettingsTile {
   /// A function that is called by tap on a tile
   final Function(BuildContext context)? onPressed;
 
-  late final Color? activeSwitchColor;
-  late final Widget? value;
-  late final Function(bool value)? onToggle;
-  late final SettingsTileType tileType;
-  late final bool? initialValue;
-  late final bool enabled;
+  /// Expand duration for the expandable tile
+  final Duration expandDuration = Duration(seconds: 1);
+
+  /// Contract duration for the expandable tile
+  final Duration contractDuration = Duration(milliseconds: 300);
+
+  /// Expand curve for the expandable tile
+  final Curve expandCurve = Curves.fastLinearToSlowEaseIn;
+
+  /// Contract curve for the expandable tile
+  final Curve contractCurve = Curves.fastOutSlowIn;
+
+  /// Builder for the expandable tile
+  /// Only argument is [close], which is a function to close the tile
+  final BuilderFunction? builder;
+
+  final Color? activeSwitchColor;
+  final Widget? value;
+  final Function(bool value)? onToggle;
+  final SettingsTileType tileType;
+  final bool? initialValue;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -99,6 +133,11 @@ class SettingsTile extends AbstractSettingsTile {
           activeSwitchColor: activeSwitchColor,
           initialValue: initialValue ?? false,
           trailing: trailing,
+          builder: builder,
+          expandDuration: expandDuration,
+          contractDuration: contractDuration,
+          expandCurve: expandCurve,
+          contractCurve: contractCurve,
         );
       case DevicePlatform.iOS:
       case DevicePlatform.macOS:


### PR DESCRIPTION
This PR adds a new settings tile: **An expandable Settings Tile**

It allows you to add content that should be expanded after you tap on the settings.

Example video:

![untitled](https://user-images.githubusercontent.com/50424412/186979535-e05c82ad-14df-4368-b3b7-50bd4aab4118.gif)

You can use it the following way:

```dart
SettingsTile.expandableTile(
  title: Text('You want a ${speed.toString().split(".")[1]} speed'),
  description: Text('Choose your speed'),
  builder: (close) => Column(
    children: Speed.values
        .map(
          (speedValue) => RadioListTile<Speed>(
            title: Text(speedValue.toString().split(".")[1]),
            value: speedValue,
            groupValue: speed,
            onChanged: (newValue) {
              if (newValue == null) {
                return;
              }

              close();

              setState(() {
                speed = newValue;
              });
            },
          ),
        )
        .toList(),
  ),
)
```

I have only added it to Android yet, as I first want to know what you guys think. If you like it, I will also add it for iOS too. I'd also suggest then changing the current architecture a bit to make the code more robust for future changes.

**THIS PR IS NOT READY TO BE MERGED YET!**
