### PR TITLE
feat: add native mobile settings screens

### DIFF
--- a/example/lib/screens/gallery/android_native_settings_screen.dart
+++ b/example/lib/screens/gallery/android_native_settings_screen.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class AndroidNativeSettingsScreen extends StatefulWidget {
+  const AndroidNativeSettingsScreen({Key key}) : super(key: key);
+
+  @override
+  State<AndroidNativeSettingsScreen> createState() =>
+      _AndroidNativeSettingsScreenState();
+}
+
+class _AndroidNativeSettingsScreenState
+    extends State<AndroidNativeSettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Color.fromRGBO(240, 240, 240, 1),
+      appBar: AppBar(title: Text('Settings')),
+      body: ListView(
+        shrinkWrap: false,
+        children: [
+          Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 24.0, right: 24),
+              child: Icon(
+                Icons.person_pin,
+                size: 40,
+                color: Colors.blue.shade900,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Text(
+              'Settings',
+              style: TextStyle(
+                fontSize: 30,
+                fontWeight: FontWeight.w400,
+                color: Colors.black,
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24),
+            child: TextField(
+              autofocus: false,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w400,
+              ),
+              decoration: InputDecoration(
+                prefixIcon: Icon(
+                  Icons.search,
+                  color: Colors.black,
+                ),
+                filled: true,
+                fillColor: Colors.white,
+                hintText: 'Search Settings',
+                contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 14.0, vertical: 13.0),
+                focusedBorder: OutlineInputBorder(
+                  borderSide: BorderSide(color: Colors.white),
+                  borderRadius: BorderRadius.circular(25.7),
+                ),
+                enabledBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: Colors.white),
+                  borderRadius: BorderRadius.circular(25.7),
+                ),
+              ),
+            ),
+          ),
+          SettingsList(
+            platform: DevicePlatform.android,
+            physics: ClampingScrollPhysics(),
+            shrinkWrap: true,
+            sections: [
+              SettingsSection(
+                tiles: [
+                  SettingsTile(
+                    title: Text('Network & internet'),
+                    description: Text('Mobile, Wi-Fi, hotspot'),
+                    leading: Icon(Icons.wifi),
+                  ),
+                  SettingsTile(
+                    title: Text('Connected devices'),
+                    description: Text('Bluetooth, pairing'),
+                    leading: Icon(Icons.devices_other),
+                  ),
+                  SettingsTile(
+                    title: Text('Apps'),
+                    description: Text('Assistant, recent apps, default apps'),
+                    leading: Icon(Icons.apps),
+                  ),
+                  SettingsTile(
+                    title: Text('Notifications'),
+                    description: Text('Notification history, conversations'),
+                    leading: Icon(Icons.notifications_none),
+                  ),
+                  SettingsTile(
+                    title: Text('Battery'),
+                    description: Text('100%'),
+                    leading: Icon(Icons.battery_full),
+                  ),
+                  SettingsTile(
+                    title: Text('Storage'),
+                    description: Text('30% used - 5.60 GB free'),
+                    leading: Icon(Icons.storage),
+                  ),
+                  SettingsTile(
+                    title: Text('Sound & vibration'),
+                    description: Text('Volume, haptics, Do Not Disturb'),
+                    leading: Icon(Icons.volume_up_outlined),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/screens/gallery/ios_developer_screen.dart
+++ b/example/lib/screens/gallery/ios_developer_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:settings_ui/settings_ui.dart';
 
 class IosDeveloperScreen extends StatefulWidget {

--- a/example/lib/screens/gallery/ios_native_settings_screen.dart
+++ b/example/lib/screens/gallery/ios_native_settings_screen.dart
@@ -1,0 +1,143 @@
+import 'package:example/widgets/leading_ios_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class IosNativeSettingsScreen extends StatefulWidget {
+  const IosNativeSettingsScreen({Key key}) : super(key: key);
+
+  @override
+  State<IosNativeSettingsScreen> createState() =>
+      _IosNativeSettingsScreenState();
+}
+
+class _IosNativeSettingsScreenState extends State<IosNativeSettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(middle: Text('Settings')),
+      child: SafeArea(
+        bottom: false,
+        child: SettingsList(
+          platform: DevicePlatform.iOS,
+          sections: [
+            /// Person Settings Section
+            SettingsSection(
+              title: Text(
+                'Settings',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 30,
+                  color: Colors.black,
+                ),
+              ),
+              tiles: [
+                SettingsTile(
+                  leading: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8.0),
+                    child: CircleAvatar(
+                      child: Icon(
+                        CupertinoIcons.person_alt_circle,
+                        size: 45,
+                        color: Colors.white,
+                      ),
+                      radius: 25,
+                      backgroundColor: Colors.grey,
+                    ),
+                  ),
+                  title: Text(
+                    'Sign in to your iPhone',
+                    style: TextStyle(color: Colors.blueAccent),
+                  ),
+                  titleDescription: Text(
+                    'Set up iCloud, the App Store, and more.',
+                    style: TextStyle(
+                      color: Colors.grey,
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+
+            /// Screen Time Section
+            SettingsSection(
+              tiles: [
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.deepPurple,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.hourglass,
+                  ),
+                  title: Text('Screen time'),
+                )
+              ],
+            ),
+
+            /// Settings General Section
+            SettingsSection(
+              tiles: [
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.grey,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.settings,
+                  ),
+                  title: Text('General'),
+                ),
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.blue,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.person_alt_circle,
+                  ),
+                  title: Text('Accessibility'),
+                ),
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.blue,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.hand_raised_fill,
+                  ),
+                  title: Text('Privacy'),
+                ),
+              ],
+            ),
+            SettingsSection(
+              tiles: [
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.grey,
+                    iconColor: Colors.white,
+                    iconData: Icons.key,
+                  ),
+                  title: Text('Passwords'),
+                )
+              ],
+            ),
+            SettingsSection(
+              tiles: [
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.red,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.news,
+                  ),
+                  title: Text('News'),
+                ),
+                SettingsTile.navigation(
+                  leading: LeadingIosWidget(
+                    backgroundColor: Colors.black,
+                    iconColor: Colors.white,
+                    iconData: CupertinoIcons.paperplane,
+                  ),
+                  title: Text('Maps'),
+                )
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/screens/gallery_screen.dart
+++ b/example/lib/screens/gallery_screen.dart
@@ -1,6 +1,8 @@
+import 'package:example/screens/gallery/android_native_settings_screen.dart';
 import 'package:example/screens/gallery/android_settings_screen.dart';
 import 'package:example/screens/gallery/cross_platform_settings_screen.dart';
 import 'package:example/screens/gallery/ios_developer_screen.dart';
+import 'package:example/screens/gallery/ios_native_settings_screen.dart';
 import 'package:example/screens/gallery/web_chrome_settings.dart';
 import 'package:example/utils/navigation.dart';
 import 'package:flutter/cupertino.dart';
@@ -66,6 +68,28 @@ class GalleryScreen extends StatelessWidget {
                     context: context,
                     screen: WebChromeSettings(),
                     style: NavigationRouteStyle.material,
+                  );
+                },
+              ),
+              SettingsTile.navigation(
+                leading: Icon(CupertinoIcons.device_phone_portrait),
+                title: Text('iOS Native Settings Screen'),
+                onPressed: (context) {
+                  Navigation.navigateTo(
+                    context: context,
+                    screen: IosNativeSettingsScreen(),
+                    style: NavigationRouteStyle.cupertino,
+                  );
+                },
+              ),
+              SettingsTile.navigation(
+                leading: Icon(Icons.adb),
+                title: Text('Android Native Settings Screen'),
+                onPressed: (context) {
+                  Navigation.navigateTo(
+                    context: context,
+                    screen: AndroidNativeSettingsScreen(),
+                    style: NavigationRouteStyle.cupertino,
                   );
                 },
               ),

--- a/example/lib/widgets/leading_ios_widget.dart
+++ b/example/lib/widgets/leading_ios_widget.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/cupertino.dart';
+
+class LeadingIosWidget extends StatelessWidget {
+  final Color backgroundColor;
+  final Color iconColor;
+  final IconData iconData;
+
+  const LeadingIosWidget({
+    Key key,
+    this.backgroundColor,
+    this.iconColor,
+    this.iconData,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 30,
+      height: 30,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.all(Radius.circular(7)),
+      ),
+      child: Icon(
+        iconData,
+        color: iconColor,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Adds native mobile settings screens

Native settings screens from Android and iOS:

<img src="https://user-images.githubusercontent.com/82770717/205277491-8e0b6e1e-4674-419f-b5d3-503b89b58c96.png" width="200"> <img src="https://user-images.githubusercontent.com/82770717/205276853-f70ffa74-ac0b-41e4-81ed-4476a0e0c350.png" width="200">

Settings screens with our setting tiles: 

<img src="https://user-images.githubusercontent.com/82770717/205317447-b662007f-d292-4ad7-bcd9-11d481dc72ec.png" width="200"> <img src="https://user-images.githubusercontent.com/82770717/205276975-4ac5f7b3-27e6-483e-be47-126131065520.png" width="200">

