### PR TITLE
feat: full Flutter test coverage

### DIFF
--- a/test/settings_tests/setting_tile_tests.dart
+++ b/test/settings_tests/setting_tile_tests.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:settings_ui/src/tiles/platforms/android_settings_tile.dart';
+import 'package:settings_ui/src/tiles/platforms/ios_settings_tile.dart';
+import 'package:settings_ui/src/tiles/platforms/web_settings_tile.dart';
+
+import '../test_widget_screen.dart';
+
+void settingsTileTests(DevicePlatform platform) {
+  testWidgets('Settings Tile should render correctly', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          settingsTiles: [
+            SettingsTile(
+              title: const Text('Abstract settings tile'),
+              value: const Text('Tile Value'),
+              trailing: const Icon(
+                Icons.ac_unit,
+                size: 24,
+              ),
+            ),
+            SettingsTile(
+              title: const Text('UI settings screen'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('Abstract settings tile'), findsOneWidget);
+    expect(find.text('UI settings screen'), findsOneWidget);
+    expect(find.byIcon(Icons.ac_unit), findsOneWidget);
+
+    if (platform == DevicePlatform.android ||
+        platform == DevicePlatform.fuchsia ||
+        platform == DevicePlatform.linux) {
+      expect(find.byType(AndroidSettingsTile), findsWidgets);
+      expect(find.byType(IOSSettingsTile), findsNothing);
+      expect(find.byType(WebSettingsTile), findsNothing);
+      expect(find.text('Tile Value'), findsOneWidget);
+    }
+    if (platform == DevicePlatform.iOS ||
+        platform == DevicePlatform.macOS ||
+        platform == DevicePlatform.windows) {
+      expect(find.byType(IOSSettingsTile), findsWidgets);
+      expect(find.byType(AndroidSettingsTile), findsNothing);
+      expect(find.byType(WebSettingsTile), findsNothing);
+    }
+    if (platform == DevicePlatform.web) {
+      expect(find.byType(WebSettingsTile), findsWidgets);
+      expect(find.byType(IOSSettingsTile), findsNothing);
+      expect(find.byType(AndroidSettingsTile), findsNothing);
+      expect(find.text('Tile Value'), findsOneWidget);
+    }
+  });
+
+  testWidgets('Settings Switch Tile should render correctly', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          settingsTiles: [
+            SettingsTile.switchTile(
+              title: const Text('Switch tile with null toggle value'),
+              initialValue: true,
+              onToggle: null,
+              trailing: const Icon(
+                Icons.ac_unit,
+                size: 24,
+              ),
+            ),
+            SettingsTile.switchTile(
+              title: const Text('Switch tile without null toggle value'),
+              onToggle: (bool value) {},
+              initialValue: false,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('Switch tile with null toggle value'), findsOneWidget);
+    expect(find.text('Switch tile without null toggle value'), findsOneWidget);
+    expect(find.byIcon(Icons.ac_unit), findsOneWidget);
+
+    if (platform == DevicePlatform.android ||
+        platform == DevicePlatform.fuchsia ||
+        platform == DevicePlatform.linux ||
+        platform == DevicePlatform.web) {
+      expect(find.byType(Switch), findsWidgets);
+      expect(find.byType(CupertinoSwitch), findsNothing);
+    }
+    if (platform == DevicePlatform.iOS ||
+        platform == DevicePlatform.macOS ||
+        platform == DevicePlatform.windows) {
+      expect(find.byType(Switch), findsNothing);
+      expect(find.byType(CupertinoSwitch), findsWidgets);
+    }
+  });
+
+  testWidgets('Settings IOS Navigation Tile should render correctly',
+      (tester) async {
+    if (platform == DevicePlatform.iOS ||
+        platform == DevicePlatform.macOS ||
+        platform == DevicePlatform.windows) {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TestWidgetScreen(
+            platform: platform,
+            settingsTiles: [
+              SettingsTile.navigation(
+                title: const Text('Navigation tile with value'),
+                onPressed: (context) {},
+                value: const Text('Settings Tile Value'),
+              ),
+              SettingsTile.navigation(
+                title: const Text('Navigation tile without value'),
+                onPressed: (context) {},
+                titleDescription: const Text('Title description value'),
+                trailing: const Icon(
+                  Icons.ac_unit,
+                  size: 24,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+      expect(find.text('Navigation tile with value'), findsOneWidget);
+      expect(find.text('Navigation tile without value'), findsOneWidget);
+      expect(find.text('Settings Tile Value'), findsOneWidget);
+      expect(find.text('Title description value'), findsOneWidget);
+      expect(find.byIcon(CupertinoIcons.chevron_forward), findsWidgets);
+      expect(find.byIcon(Icons.ac_unit), findsOneWidget);
+      expect(find.byType(IOSSettingsTile), findsWidgets);
+    }
+  });
+}

--- a/test/settings_tests/settings_list_tests.dart
+++ b/test/settings_tests/settings_list_tests.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+import '../test_widget_screen.dart';
+
+void settingsListTests(DevicePlatform? platform) {
+  group('Settings List tests in Material App ', () {
+    testWidgets(
+        'Settings list with material application type should render correctly',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TestWidgetScreen(
+            platform: platform,
+            applicationType: ApplicationType.material,
+            settingsTiles: [
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byType(SettingsList), findsOneWidget);
+      expect(find.byType(SettingsSection), findsOneWidget);
+    });
+
+    testWidgets(
+        'Settings list with both application type should render correctly',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TestWidgetScreen(
+            platform: platform,
+            applicationType: ApplicationType.both,
+            settingsTiles: [
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byType(SettingsList), findsOneWidget);
+      expect(find.byType(SettingsSection), findsOneWidget);
+    });
+
+    testWidgets('Settings list with big size screen should render correctly',
+        (tester) async {
+      tester.binding.window.devicePixelRatioTestValue = (2.625);
+      final dpi = tester.binding.window.devicePixelRatio;
+      tester.binding.window.physicalSizeTestValue = Size(900 * dpi, 1200 * dpi);
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(),
+          child: MaterialApp(
+            home: TestWidgetScreen(
+              platform: platform,
+              applicationType: ApplicationType.material,
+              settingsTiles: [
+                SettingsTile.navigation(
+                  title: const Text('Abstract settings screen'),
+                  leading: const Icon(CupertinoIcons.wrench),
+                  description:
+                      const Text('UI created to show plugin\'s possibilities'),
+                  onPressed: (context) {},
+                ),
+                SettingsTile.navigation(
+                  title: const Text('Abstract settings screen'),
+                  leading: const Icon(CupertinoIcons.wrench),
+                  description:
+                      const Text('UI created to show plugin\'s possibilities'),
+                  onPressed: (context) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SettingsList), findsOneWidget);
+      expect(find.byType(SettingsSection), findsOneWidget);
+      tester.binding.window.clearAllTestValues();
+    });
+  });
+
+  group('Settings List tests in Cupertino App with different platforms', () {
+    testWidgets('Settings list should render correctly', (tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultMaterialLocalizations.delegate,
+            DefaultWidgetsLocalizations.delegate,
+            DefaultCupertinoLocalizations.delegate,
+          ],
+          home: TestWidgetScreen(
+            platform: platform,
+            applicationType: ApplicationType.cupertino,
+            settingsTiles: [
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+              SettingsTile.navigation(
+                title: const Text('Abstract settings screen'),
+                leading: const Icon(CupertinoIcons.wrench),
+                description:
+                    const Text('UI created to show plugin\'s possibilities'),
+                onPressed: (context) {},
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.byType(SettingsList), findsOneWidget);
+      expect(find.byType(SettingsSection), findsOneWidget);
+    });
+  });
+}

--- a/test/settings_tests/settings_sections_tests.dart
+++ b/test/settings_tests/settings_sections_tests.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:settings_ui/src/sections/platforms/android_settings_section.dart';
+import 'package:settings_ui/src/sections/platforms/ios_settings_section.dart';
+import 'package:settings_ui/src/sections/platforms/web_settings_section.dart';
+
+import '../test_widget_screen.dart';
+
+void settingsSectionsTests(DevicePlatform? platform) {
+  testWidgets('Settings Section should render correctly', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          applicationType: ApplicationType.material,
+          settingsTiles: [
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(find.text('General'), findsOneWidget);
+    if (platform == DevicePlatform.android ||
+        platform == DevicePlatform.fuchsia ||
+        platform == DevicePlatform.linux) {
+      expect(find.byType(AndroidSettingsSection), findsOneWidget);
+      expect(find.byType(IOSSettingsSection), findsNothing);
+      expect(find.byType(WebSettingsSection), findsNothing);
+    }
+    if (platform == DevicePlatform.iOS ||
+        platform == DevicePlatform.macOS ||
+        platform == DevicePlatform.windows) {
+      expect(find.byType(IOSSettingsSection), findsOneWidget);
+      expect(find.byType(AndroidSettingsSection), findsNothing);
+      expect(find.byType(WebSettingsSection), findsNothing);
+    }
+    if (platform == DevicePlatform.web) {
+      expect(find.byType(WebSettingsSection), findsOneWidget);
+      expect(find.byType(IOSSettingsSection), findsNothing);
+      expect(find.byType(AndroidSettingsSection), findsNothing);
+    }
+  });
+
+  testWidgets('Custom Settings Section should render correctly',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          applicationType: ApplicationType.material,
+          settingsTiles: [
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(find.byType(SettingsSection), findsWidgets);
+    expect(find.text('Custom settings section'), findsOneWidget);
+    expect(find.byType(CustomSettingsSection), findsOneWidget);
+  });
+}

--- a/test/settings_tests/settings_tile_on_tap_tests.dart
+++ b/test/settings_tests/settings_tile_on_tap_tests.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+import '../test_widget_screen.dart';
+
+void settingsTileOnTapTests(DevicePlatform platform) {
+  testWidgets('Settings Tile onPressed is called', (tester) async {
+    bool isPressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          settingsTiles: [
+            SettingsTile(
+              title: const Text('Abstract settings tile'),
+              value: const Text('Tile Value'),
+              onPressed: (context) {
+                isPressed = true;
+              },
+              trailing: const Icon(
+                Icons.ac_unit,
+                size: 24,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.tap(find.byType(SettingsTile));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(isPressed, true);
+  });
+
+  testWidgets('Settings Switch Tile onPressed is called', (tester) async {
+    bool isPressed = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          platform: platform,
+          settingsTiles: [
+            SettingsTile.switchTile(
+              title: const Text('Abstract settings tile'),
+              trailing: const Icon(Icons.ac_unit, size: 24),
+              initialValue: isPressed,
+              onToggle: (bool value) {
+                isPressed = value;
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+    if (platform == DevicePlatform.iOS ||
+        platform == DevicePlatform.macOS ||
+        platform == DevicePlatform.windows) {
+      await tester.tap(find.byType(CupertinoSwitch));
+    } else {
+      await tester.tap(find.byType(Switch));
+    }
+
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(isPressed, true);
+  });
+}

--- a/test/test_widget_screen.dart
+++ b/test/test_widget_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class TestWidgetScreen extends StatefulWidget {
+  final DevicePlatform? platform;
+  final ApplicationType applicationType;
+  final List<AbstractSettingsTile> settingsTiles;
+
+  const TestWidgetScreen({
+    Key? key,
+    this.platform,
+    this.applicationType = ApplicationType.material,
+    required this.settingsTiles,
+  }) : super(key: key);
+
+  @override
+  State<TestWidgetScreen> createState() => _TestWidgetScreenState();
+}
+
+class _TestWidgetScreenState extends State<TestWidgetScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gallery')),
+      body: SettingsList(
+        darkTheme: const SettingsThemeData(
+          dividerColor: Colors.pink,
+          tileDescriptionTextColor: Colors.blue,
+          leadingIconsColor: Colors.red,
+          settingsListBackground: Colors.grey,
+          settingsSectionBackground: Colors.tealAccent,
+          settingsTileTextColor: Colors.green,
+          tileHighlightColor: Colors.yellow,
+          titleTextColor: Colors.cyan,
+          trailingTextColor: Colors.orange,
+        ),
+        lightTheme: const SettingsThemeData(),
+        platform: widget.platform,
+        applicationType: widget.applicationType,
+        sections: [
+          SettingsSection(
+            title: const Text('General'),
+            tiles: widget.settingsTiles,
+          ),
+          CustomSettingsSection(
+            child: Container(
+              height: 50,
+              color: Colors.red,
+              child: const Text('Custom settings section'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/test/utils_tests/device_platform_tests.dart
+++ b/test/utils_tests/device_platform_tests.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:settings_ui/settings_ui.dart';
+import 'package:settings_ui/src/sections/platforms/android_settings_section.dart';
+import 'package:settings_ui/src/sections/platforms/ios_settings_section.dart';
+import 'package:settings_ui/src/sections/platforms/web_settings_section.dart';
+
+import '../test_widget_screen.dart';
+
+void devicePlatformTest(TargetPlatform targetPlatform) {
+  testWidgets('Device Platform Test', (tester) async {
+    debugDefaultTargetPlatformOverride = targetPlatform;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TestWidgetScreen(
+          settingsTiles: [
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+            SettingsTile.navigation(
+              title: const Text('Abstract settings screen'),
+              leading: const Icon(CupertinoIcons.wrench),
+              description:
+                  const Text('UI created to show plugin\'s possibilities'),
+              onPressed: (context) {},
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(find.text('General'), findsOneWidget);
+    if (targetPlatform == TargetPlatform.android ||
+        targetPlatform == TargetPlatform.fuchsia ||
+        targetPlatform == TargetPlatform.linux) {
+      expect(find.byType(AndroidSettingsSection), findsOneWidget);
+      expect(find.byType(IOSSettingsSection), findsNothing);
+      expect(find.byType(WebSettingsSection), findsNothing);
+    }
+    if (targetPlatform == TargetPlatform.iOS ||
+        targetPlatform == TargetPlatform.macOS ||
+        targetPlatform == TargetPlatform.windows) {
+      expect(find.byType(IOSSettingsSection), findsOneWidget);
+      expect(find.byType(AndroidSettingsSection), findsNothing);
+      expect(find.byType(WebSettingsSection), findsNothing);
+    }
+    debugDefaultTargetPlatformOverride = null;
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,21 +1,18 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:settings_ui/settings_ui.dart';
 import 'package:settings_ui/src/sections/platforms/android_settings_section.dart';
-import 'package:settings_ui/src/sections/platforms/ios_settings_section.dart';
-import 'package:settings_ui/src/sections/platforms/web_settings_section.dart';
 import 'package:settings_ui/src/tiles/platforms/android_settings_tile.dart';
-import 'package:settings_ui/src/tiles/platforms/ios_settings_tile.dart';
-import 'package:settings_ui/src/tiles/platforms/web_settings_tile.dart';
+
+import 'settings_tests/setting_tile_tests.dart';
+import 'settings_tests/settings_list_tests.dart';
+import 'settings_tests/settings_sections_tests.dart';
+import 'settings_tests/settings_tile_on_tap_tests.dart';
+import 'utils_tests/device_platform_tests.dart';
 
 void main() {
-  group('Android tile tests', () {
-    bool isPressed = false;
+  group('Settings Tile constructor tests ', () {
     final settingsTile = SettingsTile(
-      onPressed: (context) {
-        isPressed = true;
-      },
       title: const Text('Network & internet'),
       description: const Text('Mobile, Wi-Fi, hotspot'),
       leading: const Icon(Icons.wifi),
@@ -109,296 +106,58 @@ void main() {
 
       expect(iconWidget.data.color, const Color(0xff464646));
     });
-
-    testWidgets('Settings Tile onPressed is called', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.android,
-      ));
-      await tester.tap(find.byType(AndroidSettingsTile));
-
-      expect(isPressed, true);
-    });
-
-    testWidgets('Settings Tile onToggle is called', (tester) async {
-      bool onToggleValue = false;
-      final onToggleTile = SettingsTile.switchTile(
-        initialValue: onToggleValue,
-        onToggle: (value) {
-          onToggleValue = value;
-        },
-        title: const Text('Notification dot on app icon'),
-      );
-
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        onToggleTile,
-        DevicePlatform.android,
-      ));
-
-      final switcherFinder = find.descendant(
-        of: find.byType(AndroidSettingsTile),
-        matching: find.byType(Switch),
-      );
-
-      await tester.tap(switcherFinder);
-      expect(onToggleValue, true);
-    });
   });
 
-  group('IOS tile tests', () {
-    bool isPressed = false;
-    final settingsTile = SettingsTile.navigation(
-      onPressed: (_) {
-        isPressed = true;
-      },
-      title: const Text('View'),
-      value: const Text('Standard'),
-      description: const Text('Choose a view for iPhone'),
-    );
-
-    testWidgets('Widget should render correctly', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-      expect(find.byType(IOSSettingsSection), findsOneWidget);
-      expect(find.byType(IOSSettingsTile), findsOneWidget);
-    });
-
-    testWidgets('Title content should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-      expect(find.text('View'), findsOneWidget);
-    });
-
-    testWidgets('Title style should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-
-      final defaultTextFinder = find.ancestor(
-          of: find.text('View'), matching: find.byType(DefaultTextStyle));
-
-      final DefaultTextStyle titleWidget =
-          tester.firstWidget(defaultTextFinder);
-
-      expect(titleWidget.style.color, Colors.black);
-      expect(titleWidget.style.fontSize, 16);
-      expect(titleWidget.style.fontWeight, null);
-    });
-
-    testWidgets('Description content should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-
-      expect(find.text('Choose a view for iPhone'), findsOneWidget);
-    });
-
-    testWidgets('Description style should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-
-      final defaultTextFinder = find.ancestor(
-          of: find.text('Choose a view for iPhone'),
-          matching: find.byType(DefaultTextStyle));
-
-      final DefaultTextStyle descriptionWidget =
-          tester.firstWidget(defaultTextFinder);
-
-      expect(descriptionWidget.style.color, const Color(0xff6d6d72));
-      expect(descriptionWidget.style.fontSize, 13);
-      expect(descriptionWidget.style.fontWeight, null);
-    });
-
-    testWidgets('Tile icon should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.iOS,
-      ));
-
-      expect(find.byIcon(CupertinoIcons.chevron_forward), findsOneWidget);
-    });
-
-    testWidgets('Settings Tile onPressed is called', (tester) async {
-      await tester.runAsync(() async {
-        await tester.pumpWidget(_wrapWithMaterialApp(
-          settingsTile,
-          DevicePlatform.iOS,
-        ));
-        await tester.tap(find.byType(IOSSettingsTile));
-
-        expect(isPressed, true);
-      });
-    });
-
-    testWidgets('Settings Tile onToggle is called', (tester) async {
-      bool onToggleValue = false;
-      final onToggleTile = SettingsTile.switchTile(
-        initialValue: onToggleValue,
-        onToggle: (value) {
-          onToggleValue = value;
-        },
-        title: const Text('Dark Appearance'),
-      );
-
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        onToggleTile,
-        DevicePlatform.iOS,
-      ));
-
-      final switcherFinder = find.descendant(
-        of: find.byType(IOSSettingsTile),
-        matching: find.byType(CupertinoSwitch),
-      );
-
-      await tester.tap(switcherFinder);
-      expect(onToggleValue, true);
-    });
+  group('Settings Lists tests for different platforms', () {
+    settingsListTests(DevicePlatform.android);
+    settingsListTests(DevicePlatform.web);
+    settingsListTests(DevicePlatform.macOS);
+    settingsListTests(DevicePlatform.iOS);
+    settingsListTests(DevicePlatform.fuchsia);
+    settingsListTests(DevicePlatform.linux);
+    settingsListTests(DevicePlatform.windows);
+    settingsListTests(DevicePlatform.device);
+    settingsListTests(null);
   });
 
-  group('Web tile tests', () {
-    bool isPressed = false;
-    final settingsTile = SettingsTile.navigation(
-      onPressed: (_) {
-        isPressed = true;
-      },
-      leading: const Icon(Icons.web),
-      title: const Text('Cookies and other site data'),
-      description:
-          const Text('Third-party cookies are blocked in Incognito mode'),
-    );
+  group('Settings sections tests for different platforms', () {
+    settingsSectionsTests(DevicePlatform.android);
+    settingsSectionsTests(DevicePlatform.web);
+    settingsSectionsTests(DevicePlatform.macOS);
+    settingsSectionsTests(DevicePlatform.iOS);
+    settingsSectionsTests(DevicePlatform.fuchsia);
+    settingsSectionsTests(DevicePlatform.linux);
+    settingsSectionsTests(DevicePlatform.windows);
+    settingsSectionsTests(DevicePlatform.device);
+  });
 
-    testWidgets('Widget should render correctly', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-      expect(find.byType(WebSettingsSection), findsOneWidget);
-      expect(find.byType(WebSettingsTile), findsOneWidget);
-    });
+  group('Device platform utils tests', () {
+    devicePlatformTest(TargetPlatform.android);
+    devicePlatformTest(TargetPlatform.fuchsia);
+    devicePlatformTest(TargetPlatform.linux);
+    devicePlatformTest(TargetPlatform.iOS);
+    devicePlatformTest(TargetPlatform.macOS);
+    devicePlatformTest(TargetPlatform.windows);
+  });
 
-    testWidgets('Title content should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-      expect(find.text('Cookies and other site data'), findsOneWidget);
-    });
+  group('Settings tile tests for different platforms ', () {
+    settingsTileTests(DevicePlatform.android);
+    settingsTileTests(DevicePlatform.fuchsia);
+    settingsTileTests(DevicePlatform.linux);
+    settingsTileTests(DevicePlatform.iOS);
+    settingsTileTests(DevicePlatform.macOS);
+    settingsTileTests(DevicePlatform.windows);
+    settingsTileTests(DevicePlatform.web);
+  });
 
-    testWidgets('Title style should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-
-      final defaultTextFinder = find.ancestor(
-        of: find.text('Cookies and other site data'),
-        matching: find.byType(DefaultTextStyle),
-      );
-
-      final DefaultTextStyle titleWidget =
-          tester.firstWidget(defaultTextFinder);
-
-      expect(titleWidget.style.color, const Color(0xff1b1b1b));
-      expect(titleWidget.style.fontSize, 18);
-      expect(titleWidget.style.fontWeight, FontWeight.w400);
-    });
-
-    testWidgets('Description content should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-
-      expect(
-        find.text('Third-party cookies are blocked in Incognito mode'),
-        findsOneWidget,
-      );
-    });
-
-    testWidgets('Description style should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-
-      final defaultTextFinder = find.ancestor(
-          of: find.text('Third-party cookies are blocked in Incognito mode'),
-          matching: find.byType(DefaultTextStyle));
-
-      final DefaultTextStyle descriptionWidget =
-          tester.firstWidget(defaultTextFinder);
-
-      expect(descriptionWidget.style.color, const Color(0xff464646));
-      expect(descriptionWidget.style.fontSize, null);
-      expect(descriptionWidget.style.fontWeight, null);
-    });
-
-    testWidgets('Leading icon should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-
-      expect(find.byIcon(Icons.web), findsOneWidget);
-    });
-
-    testWidgets('Leading icon color should match', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-
-      final iconThemeFinder = find.ancestor(
-        of: find.byIcon(Icons.web),
-        matching: find.byType(IconTheme),
-      );
-
-      final IconTheme iconWidget = tester.firstWidget(iconThemeFinder);
-
-      expect(iconWidget.data.color, const Color(0xff464646));
-    });
-
-    testWidgets('Settings Tile onPressed is called', (tester) async {
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        settingsTile,
-        DevicePlatform.web,
-      ));
-      await tester.tap(find.byType(WebSettingsTile));
-
-      expect(isPressed, true);
-    });
-
-    testWidgets('Settings Tile onToggle is called', (tester) async {
-      bool onToggleValue = false;
-      final onToggleTile = SettingsTile.switchTile(
-        initialValue: onToggleValue,
-        onToggle: (value) {
-          onToggleValue = value;
-        },
-        title: const Text('Dark Appearance'),
-      );
-
-      await tester.pumpWidget(_wrapWithMaterialApp(
-        onToggleTile,
-        DevicePlatform.web,
-      ));
-
-      final switcherFinder = find.descendant(
-        of: find.byType(WebSettingsTile),
-        matching: find.byType(Switch),
-      );
-
-      await tester.tap(switcherFinder);
-      expect(onToggleValue, true);
-    });
+  group('description', () {
+    settingsTileOnTapTests(DevicePlatform.android);
+    settingsTileOnTapTests(DevicePlatform.fuchsia);
+    settingsTileOnTapTests(DevicePlatform.linux);
+    settingsTileOnTapTests(DevicePlatform.iOS);
+    settingsTileOnTapTests(DevicePlatform.macOS);
+    settingsTileOnTapTests(DevicePlatform.windows);
+    settingsTileOnTapTests(DevicePlatform.web);
   });
 }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -140,7 +140,7 @@ void main() {
     devicePlatformTest(TargetPlatform.windows);
   });
 
-  group('Settings tile tests for different platforms ', () {
+  group('Settings tile tests for different platforms', () {
     settingsTileTests(DevicePlatform.android);
     settingsTileTests(DevicePlatform.fuchsia);
     settingsTileTests(DevicePlatform.linux);
@@ -150,7 +150,7 @@ void main() {
     settingsTileTests(DevicePlatform.web);
   });
 
-  group('description', () {
+  group('Settings tile on Tap tests for different platforms', () {
     settingsTileOnTapTests(DevicePlatform.android);
     settingsTileOnTapTests(DevicePlatform.fuchsia);
     settingsTileOnTapTests(DevicePlatform.linux);


### PR DESCRIPTION
Add full Flutter test coverage for setting UI:
adds tests to check the assignment of a value in the settings constructor;
adds tests to verify correct operation on different platforms;
adds tests to check to tap on tiles;
And More...

The screenshot below shows the percentage of settings covered by flutter tests:

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/82770717/212409080-a6ca8ff4-6e60-4941-987d-6b7dd427e99f.png">

