### PR TITLE
feat: add scroll controller for settings list 

### DIFF
--- a/example/lib/screens/gallery/android_notifications_screen.dart
+++ b/example/lib/screens/gallery/android_notifications_screen.dart
@@ -12,6 +12,7 @@ class AndroidNotificationsScreen extends StatefulWidget {
 class _AndroidNotificationsScreenState
     extends State<AndroidNotificationsScreen> {
   bool useNotificationDotOnAppIcon = true;
+  final ScrollController settingsListController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +21,7 @@ class _AndroidNotificationsScreenState
         title: Text('Notifications'),
       ),
       body: SettingsList(
+        scrollController: settingsListController,
         platform: DevicePlatform.android,
         sections: [
           SettingsSection(
@@ -28,6 +30,13 @@ class _AndroidNotificationsScreenState
               SettingsTile(
                 title: Text('App settings'),
                 description: Text('Control notifications from individual apps'),
+                onPressed: (context) {
+                  settingsListController.animateTo(
+                    150,
+                    duration: Duration(seconds: 1),
+                    curve: Curves.linear,
+                  );
+                },
               ),
               SettingsTile(
                 title: Text('Notification history'),

--- a/example/lib/screens/gallery/ios_developer_screen.dart
+++ b/example/lib/screens/gallery/ios_developer_screen.dart
@@ -11,6 +11,7 @@ class IosDeveloperScreen extends StatefulWidget {
 
 class _IosDeveloperScreen extends State<IosDeveloperScreen> {
   bool darkTheme = true;
+  final ScrollController settingsListController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -19,6 +20,7 @@ class _IosDeveloperScreen extends State<IosDeveloperScreen> {
       child: SafeArea(
         bottom: false,
         child: SettingsList(
+          scrollController: settingsListController,
           applicationType: ApplicationType.cupertino,
           platform: DevicePlatform.iOS,
           sections: [
@@ -40,7 +42,13 @@ class _IosDeveloperScreen extends State<IosDeveloperScreen> {
               title: Text('DISPLAY ZOOM'),
               tiles: [
                 SettingsTile.navigation(
-                  onPressed: (_) {},
+                  onPressed: (_) {
+                    settingsListController.animateTo(
+                      100,
+                      duration: Duration(seconds: 1),
+                      curve: Curves.linear,
+                    );
+                  },
                   title: Text('View'),
                   value: Text('Standard'),
                   description: Text(

--- a/example/lib/screens/gallery/web_chrome_settings.dart
+++ b/example/lib/screens/gallery/web_chrome_settings.dart
@@ -3,21 +3,35 @@ import 'package:example/utils/navigation.dart';
 import 'package:flutter/material.dart';
 import 'package:settings_ui/settings_ui.dart';
 
-class WebChromeSettings extends StatelessWidget {
+class WebChromeSettings extends StatefulWidget {
   const WebChromeSettings({Key? key}) : super(key: key);
+
+  @override
+  State<WebChromeSettings> createState() => _WebChromeSettingsState();
+}
+
+class _WebChromeSettingsState extends State<WebChromeSettings> {
+  final ScrollController settingsListController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Settings')),
       body: SettingsList(
+        scrollController: settingsListController,
         platform: DevicePlatform.web,
         sections: [
           SettingsSection(
             title: Text('Auto-fill'),
             tiles: [
               SettingsTile.navigation(
-                onPressed: (_) {},
+                onPressed: (context) {
+                  settingsListController.animateTo(
+                    150,
+                    duration: Duration(seconds: 1),
+                    curve: Curves.linear,
+                  );
+                },
                 leading: Icon(Icons.vpn_key),
                 title: Text('Passwords'),
               ),

--- a/lib/src/list/settings_list.dart
+++ b/lib/src/list/settings_list.dart
@@ -27,6 +27,7 @@ class SettingsList extends StatelessWidget {
     this.darkTheme,
     this.brightness,
     this.contentPadding,
+    this.scrollController,
     this.applicationType = ApplicationType.material,
     Key? key,
   }) : super(key: key);
@@ -40,6 +41,7 @@ class SettingsList extends StatelessWidget {
   final EdgeInsetsGeometry? contentPadding;
   final List<AbstractSettingsSection> sections;
   final ApplicationType applicationType;
+  final ScrollController? scrollController;
 
   @override
   Widget build(BuildContext context) {
@@ -66,6 +68,7 @@ class SettingsList extends StatelessWidget {
         themeData: themeData,
         platform: platform,
         child: ListView.builder(
+          controller: scrollController,
           physics: physics,
           shrinkWrap: shrinkWrap,
           itemCount: sections.length,


### PR DESCRIPTION
Add parameter scroll controller for settings list. 
Also, add example scroll animation on the tap settings tile for all platform screens