### PR TITLE
Add compact SettingsTile option

### DIFF
--- a/lib/src/tiles/platforms/android_settings_tile.dart
+++ b/lib/src/tiles/platforms/android_settings_tile.dart
@@ -14,6 +14,7 @@ class AndroidSettingsTile extends StatelessWidget {
     required this.activeSwitchColor,
     required this.enabled,
     required this.trailing,
+    required this.compact,
     Key? key,
   }) : super(key: key);
 
@@ -28,6 +29,7 @@ class AndroidSettingsTile extends StatelessWidget {
   final bool enabled;
   final Color? activeSwitchColor;
   final Widget? trailing;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +39,8 @@ class AndroidSettingsTile extends StatelessWidget {
     final cantShowAnimation = tileType == SettingsTileType.switchTile
         ? onToggle == null && onPressed == null
         : onPressed == null;
+
+    final double tilePadding = this.compact ? 10 : 19;
 
     return IgnorePointer(
       ignoring: !enabled,
@@ -73,8 +77,8 @@ class AndroidSettingsTile extends StatelessWidget {
                     padding: EdgeInsetsDirectional.only(
                       start: 24,
                       end: 24,
-                      bottom: 19 * scaleFactor,
-                      top: 19 * scaleFactor,
+                      bottom: tilePadding * scaleFactor,
+                      top: tilePadding * scaleFactor,
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/tiles/platforms/ios_settings_tile.dart
+++ b/lib/src/tiles/platforms/ios_settings_tile.dart
@@ -15,6 +15,7 @@ class IOSSettingsTile extends StatefulWidget {
     required this.activeSwitchColor,
     required this.enabled,
     required this.trailing,
+    required this.compact,
     Key? key,
   }) : super(key: key);
 
@@ -29,6 +30,7 @@ class IOSSettingsTile extends StatefulWidget {
   final bool enabled;
   final Color? activeSwitchColor;
   final Widget? trailing;
+  final bool compact;
 
   @override
   _IOSSettingsTileState createState() => _IOSSettingsTileState();
@@ -176,6 +178,8 @@ class _IOSSettingsTileState extends State<IOSSettingsTile> {
   ) {
     final scaleFactor = MediaQuery.of(context).textScaleFactor;
 
+    final double tilePadding = widget.compact ? 7 : 12.5;
+
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onTap: widget.onPressed == null
@@ -227,8 +231,8 @@ class _IOSSettingsTileState extends State<IOSSettingsTile> {
                         Expanded(
                           child: Padding(
                             padding: EdgeInsetsDirectional.only(
-                              top: 12.5 * scaleFactor,
-                              bottom: 12.5 * scaleFactor,
+                              top: tilePadding * scaleFactor,
+                              bottom: tilePadding * scaleFactor,
                             ),
                             child: DefaultTextStyle(
                               style: TextStyle(

--- a/lib/src/tiles/platforms/web_settings_tile.dart
+++ b/lib/src/tiles/platforms/web_settings_tile.dart
@@ -15,6 +15,7 @@ class WebSettingsTile extends StatelessWidget {
     required this.activeSwitchColor,
     required this.enabled,
     required this.trailing,
+    required this.compact,
     Key? key,
   }) : super(key: key);
 
@@ -29,11 +30,14 @@ class WebSettingsTile extends StatelessWidget {
   final bool enabled;
   final Widget? trailing;
   final Color? activeSwitchColor;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final theme = SettingsTheme.of(context);
     final scaleFactor = MediaQuery.of(context).textScaleFactor;
+
+    final double tilePadding = this.compact ? 10 : 19;
 
     final cantShowAnimation = tileType == SettingsTileType.switchTile
         ? onToggle == null && onPressed == null
@@ -74,8 +78,8 @@ class WebSettingsTile extends StatelessWidget {
                     padding: EdgeInsetsDirectional.only(
                       start: 24,
                       end: 24,
-                      bottom: 19 * scaleFactor,
-                      top: 19 * scaleFactor,
+                      bottom: tilePadding * scaleFactor,
+                      top: tilePadding * scaleFactor,
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/tiles/settings_tile.dart
+++ b/lib/src/tiles/settings_tile.dart
@@ -17,6 +17,7 @@ class SettingsTile extends AbstractSettingsTile {
     this.description,
     this.onPressed,
     this.enabled = true,
+    this.compact = false,
     Key? key,
   }) : super(key: key) {
     onToggle = null;
@@ -33,6 +34,7 @@ class SettingsTile extends AbstractSettingsTile {
     this.description,
     this.onPressed,
     this.enabled = true,
+    this.compact = false,
     Key? key,
   }) : super(key: key) {
     onToggle = null;
@@ -51,6 +53,7 @@ class SettingsTile extends AbstractSettingsTile {
     this.description,
     this.onPressed,
     this.enabled = true,
+    this.compact = false,
     Key? key,
   }) : super(key: key) {
     value = null;
@@ -78,6 +81,7 @@ class SettingsTile extends AbstractSettingsTile {
   late final SettingsTileType tileType;
   late final bool? initialValue;
   late final bool enabled;
+  late final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -96,6 +100,7 @@ class SettingsTile extends AbstractSettingsTile {
           leading: leading,
           title: title,
           enabled: enabled,
+          compact: compact,
           activeSwitchColor: activeSwitchColor,
           initialValue: initialValue ?? false,
           trailing: trailing,
@@ -113,6 +118,7 @@ class SettingsTile extends AbstractSettingsTile {
           title: title,
           trailing: trailing,
           enabled: enabled,
+          compact: compact,
           activeSwitchColor: activeSwitchColor,
           initialValue: initialValue ?? false,
         );
@@ -127,6 +133,7 @@ class SettingsTile extends AbstractSettingsTile {
           title: title,
           enabled: enabled,
           trailing: trailing,
+          compact: compact,
           activeSwitchColor: activeSwitchColor,
           initialValue: initialValue ?? false,
         );


### PR DESCRIPTION
Add a boolean parameter to create a compact version of the SettingsTile. This is something that I wanted to use in my project to get a more compact list of settings.

**Default:**
![default](https://github.com/yako-dev/flutter-settings-ui/assets/6522268/f34de99c-7c7e-4d37-8a37-521384c3bdd8)

**Compact:**
![compact](https://github.com/yako-dev/flutter-settings-ui/assets/6522268/70b524ae-8ca6-4d86-9ac8-e8bfabd9b311)
