### PR TITLE
feat: add web platform support for pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,11 @@ dev_dependencies:
   flutter_lints: ^3.0.1
 
 flutter:
+
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:


### PR DESCRIPTION
Now on pub.dev all supported platforms should be displayed.