### PR TITLE
fix: flip arrow in iOS navigation tile for RTL languages

### DIFF
--- a/lib/src/tiles/platforms/ios_settings_tile.dart
+++ b/lib/src/tiles/platforms/ios_settings_tile.dart
@@ -171,7 +171,9 @@ class IOSSettingsTileState extends State<IOSSettingsTile> {
               data: IconTheme.of(context)
                   .copyWith(color: theme.themeData.leadingIconsColor),
               child: Icon(
-                CupertinoIcons.chevron_forward,
+                PlatformUtils.languageIsRTL(context)
+                    ? CupertinoIcons.chevron_back
+                    : CupertinoIcons.chevron_forward,
                 size: 18 * scaleFactor,
               ),
             ),

--- a/lib/src/utils/platform_utils.dart
+++ b/lib/src/utils/platform_utils.dart
@@ -48,4 +48,24 @@ class PlatformUtils {
         return DevicePlatform.windows;
     }
   }
+
+  static bool languageIsRTL(BuildContext context) {
+    const rtlLanguages = [
+      "ar",
+      "arc",
+      "dv",
+      "fa",
+      "ha",
+      "he",
+      "khw",
+      "ks",
+      "ku",
+      "ps",
+      "ur",
+      "yi"
+    ];
+    final language = Localizations.localeOf(context).languageCode.toLowerCase();
+
+    return rtlLanguages.contains(language);
+  }
 }


### PR DESCRIPTION
Now SettingsTile.navigation support  RTL languages.
Before:
![simulator_screenshot_657F6143-1A12-43BA-918C-A14B2AC91860](https://github.com/yako-dev/flutter-settings-ui/assets/92673427/03c3ebe4-23b5-46f0-892c-2ab09534101c)

After:
![simulator_screenshot_19499159-76FF-4930-BB9E-F181680453BB](https://github.com/yako-dev/flutter-settings-ui/assets/92673427/8f433bf3-fe6a-4fc8-9f05-e5fffe782409)

